### PR TITLE
Add placeholder for member view when no submissions exist

### DIFF
--- a/src/routes/member.ts
+++ b/src/routes/member.ts
@@ -49,7 +49,7 @@ export const view = async (req: MulmRequest, res: Response) => {
 		plantTotalPoints,
 		coralTotalPoints,
 		isLoggedIn: Boolean(viewer),
-		isSelf: viewer && viewer.id == member.id,
-		isAdmin: viewer && viewer.is_admin,
+		isSelf,
+		isAdmin,
 	});
 }

--- a/src/views/member.pug
+++ b/src/views/member.pug
@@ -106,6 +106,8 @@ html
 			section.bg-gray-100.py-16
 				div(class="max-w-2xl mx-auto text-center px-4")
 					div(class="bg-white rounded-lg shadow-md p-8")
-						div(class="text-6xl mb-4") 🐠
+						div(class="text-6xl mb-4" aria-label="Fish icon") 🐠
 						h3(class="text-2xl font-bold text-gray-800 mb-2") No Submissions Yet
 						p(class="text-gray-600 mb-6") This member hasn't made any submissions to the program.
+						if isSelf
+							a(href="/submit" class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500") Start Your First Submission

--- a/src/views/member.pug
+++ b/src/views/member.pug
@@ -58,7 +58,7 @@ html
 
 	body.bg-white.text-gray-800
 		+pageHeader(isLoggedIn, member.display_name)
-		
+
 		if member.awards && member.awards.length > 0
 			section.bg-blue-50.py-8
 				div(class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8")
@@ -82,20 +82,30 @@ html
 										div(class="text-sm text-gray-500")
 											- const awardDate = new Date(award.date_awarded).toLocaleDateString();
 											= awardDate
-		if fishSubs.length > 0
-			section.bg-gray-100
-				div.w-full.text-center.px-4
-					h3(class="text-xl lg:text-4xl font-extrabold mb-4") Breeders Awards Submissions
-					+submissionTable(fishSubs, fishTotalPoints)
+		- const hasAnySubmissions = fishSubs.length > 0 || plantSubs.length > 0 || coralSubs.length > 0;
 
-		if plantSubs.length > 0
-			section.bg-gray-100
-				div.w-full.text-center.px-4
-					h3(class="text-xl lg:text-4xl font-extrabold mb-4") Horticultural Awards Submissions
-					+submissionTable(plantSubs, plantTotalPoints)
+		if hasAnySubmissions
+			if fishSubs.length > 0
+				section.bg-gray-100
+					div.w-full.text-center.px-4
+						h3(class="text-xl lg:text-4xl font-extrabold mb-4") Breeders Awards Submissions
+						+submissionTable(fishSubs, fishTotalPoints)
 
-		if coralSubs.length > 0
-			section.bg-gray-100
-				div.w-full.text-center.px-4
-					h3(class="text-xl lg:text-4xl font-extrabold mb-4") Coral Awards Submissions
-					+submissionTable(coralSubs, coralTotalPoints)
+			if plantSubs.length > 0
+				section.bg-gray-100
+					div.w-full.text-center.px-4
+						h3(class="text-xl lg:text-4xl font-extrabold mb-4") Horticultural Awards Submissions
+						+submissionTable(plantSubs, plantTotalPoints)
+
+			if coralSubs.length > 0
+				section.bg-gray-100
+					div.w-full.text-center.px-4
+						h3(class="text-xl lg:text-4xl font-extrabold mb-4") Coral Awards Submissions
+						+submissionTable(coralSubs, coralTotalPoints)
+		else
+			section.bg-gray-100.py-16
+				div(class="max-w-2xl mx-auto text-center px-4")
+					div(class="bg-white rounded-lg shadow-md p-8")
+						div(class="text-6xl mb-4") 🐠
+						h3(class="text-2xl font-bold text-gray-800 mb-2") No Submissions Yet
+						p(class="text-gray-600 mb-6") This member hasn't made any submissions to the program.


### PR DESCRIPTION
## Summary
Addresses issue #38 by adding a user-friendly placeholder when viewing a member's profile who has no submissions.

## Changes Made
- Display centered placeholder with fish emoji and friendly message when no submissions exist
- Add call-to-action button for member's own profile to encourage first submission
- Respect user permissions (submit button only shows to member themselves)
- Maintain consistent styling with application's design system
- Ensure responsive design works on all screen sizes

## Screenshots
The placeholder shows:
- 🐠 Fish emoji for visual appeal
- "No Submissions Yet" heading
- Descriptive text explaining the empty state
- "Start Your First Submission" button (only for the member's own profile)

## Test Plan
- [x] Build succeeds without errors
- [x] All existing tests pass
- [x] Template renders correctly with empty submissions
- [x] Submit button only appears for member's own profile
- [x] Design is responsive and consistent with app styling

## Benefits
- Improved user experience for empty states
- Clear guidance for new members on how to get started
- Professional appearance instead of blank sections

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)