### PR TITLE
feat(submissions): require manual confirmation before approval queue

### DIFF
--- a/db/migrations/053-add-final-submission.sql
+++ b/db/migrations/053-add-final-submission.sql
@@ -1,0 +1,18 @@
+-- Add final_submission_on column to track when the submitter (or an admin)
+-- confirms the fish/plant/coral was brought to a monthly meeting and is
+-- ready to enter the admin approval queue.
+--
+-- After the waiting period elapses, a submission no longer auto-promotes
+-- into the approval queue. Instead the submitter must click a button that
+-- sets this column. The approval queue query requires this column to be
+-- non-null.
+--
+-- Backfill: any already-approved submission counts as final-submitted at
+-- the moment it was approved, so historical data still shows up correctly
+-- and the existing approval queue isn't disrupted for in-flight items.
+
+ALTER TABLE submissions ADD COLUMN final_submission_on DATETIME;
+
+UPDATE submissions
+SET final_submission_on = approved_on
+WHERE approved_on IS NOT NULL;

--- a/e2e/admin-workflows.spec.ts
+++ b/e2e/admin-workflows.spec.ts
@@ -49,14 +49,15 @@ test.describe("Admin - Changes Requested Workflow", () => {
 
 			adminId = admin.id;
 
-			// Create submitted submission with witness confirmation
-			// Set witnessed date to 70 days ago to ensure waiting period is satisfied
+			// Create a submission already in the approval queue: witnessed past
+			// waiting period and submitter has clicked "Brought to Meeting"
 			submissionId = await createTestSubmission({
 				memberId: user.id,
 				submitted: true,
 				witnessed: true,
 				witnessedBy: admin.id,
 				witnessedDaysAgo: 70,
+				finalSubmitted: true,
 			});
 		} finally {
 			await db.close();
@@ -130,13 +131,15 @@ test.describe("Admin - Changes Requested Workflow", () => {
 				throw new Error("Test users not found in database");
 			}
 
-			// Create submission with witness confirmation (recently witnessed, still in waiting period)
+			// Create submission already in the approval queue (past waiting
+			// period and submitter has clicked "Brought to Meeting")
 			submissionId = await createTestSubmission({
 				memberId: user.id,
 				submitted: true,
 				witnessed: true,
 				witnessedBy: admin.id,
-				witnessedDaysAgo: 0, // Just witnessed today - still in waiting period
+				witnessedDaysAgo: 70,
+				finalSubmitted: true,
 			});
 		} finally {
 			await db.close();
@@ -236,13 +239,14 @@ test.describe("Admin - Changes Requested Workflow", () => {
 				throw new Error("Test users not found in database");
 			}
 
-			// Create submission with witness confirmation
+			// Create submission already in the approval queue
 			submissionId = await createTestSubmission({
 				memberId: user.id,
 				submitted: true,
 				witnessed: true,
 				witnessedBy: admin.id,
-				witnessedDaysAgo: 0, // Just witnessed today - still in waiting period
+				witnessedDaysAgo: 70,
+				finalSubmitted: true,
 			});
 
 			// Set changes_requested fields directly in database

--- a/e2e/helpers/submissions.ts
+++ b/e2e/helpers/submissions.ts
@@ -22,10 +22,11 @@ export interface TestSubmissionOptions {
 
 	/**
 	 * Whether the submitter has clicked "Brought to Meeting" to enter the
-	 * approval queue. Defaults to true when witnessed (or approved) so legacy
-	 * tests that simulate "ready to approve" state continue to work without
-	 * change. Pass false explicitly to test the awaiting-final-submission
-	 * state introduced by the manual approval-queue gating change.
+	 * approval queue. Defaults to true when approved (so historical approved
+	 * rows look consistent with the migration backfill) and false otherwise.
+	 * Tests that simulate a submission already in the approval queue should
+	 * pass true explicitly. Tests that exercise the awaiting-final-submission
+	 * state should leave it as the default.
 	 */
 	finalSubmitted?: boolean;
 
@@ -77,11 +78,10 @@ export async function createTestSubmission(options: TestSubmissionOptions): Prom
 
 	const approvedOn = options.approved ? now : null;
 
-	// Default final_submission_on to "set" when witnessed or approved so that
-	// existing approval-flow tests continue to find their submissions in the
-	// admin approval queue. Tests can opt out with finalSubmitted: false.
-	const shouldSetFinalSubmission =
-		options.finalSubmitted ?? Boolean(options.witnessed || options.approved);
+	// Approved submissions always have final_submission_on set (matches the
+	// migration backfill). Otherwise default to false so tests are explicit
+	// about whether the submitter has clicked "Brought to Meeting".
+	const shouldSetFinalSubmission = options.finalSubmitted ?? Boolean(options.approved);
 	const finalSubmissionOn = shouldSetFinalSubmission ? now : null;
 
 	// Set defaults based on species type

--- a/e2e/helpers/submissions.ts
+++ b/e2e/helpers/submissions.ts
@@ -20,6 +20,15 @@ export interface TestSubmissionOptions {
 	approvedBy?: number;
 	points?: number;
 
+	/**
+	 * Whether the submitter has clicked "Brought to Meeting" to enter the
+	 * approval queue. Defaults to true when witnessed (or approved) so legacy
+	 * tests that simulate "ready to approve" state continue to work without
+	 * change. Pass false explicitly to test the awaiting-final-submission
+	 * state introduced by the manual approval-queue gating change.
+	 */
+	finalSubmitted?: boolean;
+
 	// Species identification (defaults to Fish: Guppy)
 	speciesType?: "Fish" | "Invert" | "Plant" | "Coral";
 	speciesClass?: string;
@@ -67,6 +76,13 @@ export async function createTestSubmission(options: TestSubmissionOptions): Prom
 	const reproductionDate = new Date(Date.now() - reproductionDaysAgo * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
 
 	const approvedOn = options.approved ? now : null;
+
+	// Default final_submission_on to "set" when witnessed or approved so that
+	// existing approval-flow tests continue to find their submissions in the
+	// admin approval queue. Tests can opt out with finalSubmitted: false.
+	const shouldSetFinalSubmission =
+		options.finalSubmitted ?? Boolean(options.witnessed || options.approved);
+	const finalSubmissionOn = shouldSetFinalSubmission ? now : null;
 
 	// Set defaults based on species type
 	const speciesType = options.speciesType || "Fish";
@@ -133,8 +149,9 @@ export async function createTestSubmission(options: TestSubmissionOptions): Prom
 			witness_verification_status,
 			approved_on,
 			approved_by,
-			points
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			points,
+			final_submission_on
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		options.memberId,
 		program,
 		speciesType,
@@ -168,7 +185,8 @@ export async function createTestSubmission(options: TestSubmissionOptions): Prom
 		options.witnessed ? "confirmed" : "pending",
 		approvedOn,
 		options.approvedBy || null,
-		options.points || null
+		options.points || null,
+		finalSubmissionOn
 	);
 
 	return result.lastID!;

--- a/e2e/submission-lifecycle.spec.ts
+++ b/e2e/submission-lifecycle.spec.ts
@@ -26,8 +26,10 @@ test.describe("Submission Complete Lifecycle", () => {
 		await ensureTestUserExists(TEST_ADMIN.email, TEST_ADMIN.password, TEST_ADMIN.displayName, true);
 	});
 
-	test("happy path: draft → submit → witness → wait → approve", async ({ page }) => {
-		// Step 1: Create a witnessed submission directly (witnessed 70 days ago to satisfy waiting period)
+	test("happy path: draft → submit → witness → wait → bring to meeting → approve", async ({ page }) => {
+		// Step 1: Create a witnessed submission directly (witnessed 70 days ago to satisfy waiting period).
+		// final_submission_on is intentionally null so we can exercise the
+		// "Brought to Meeting" click as a real step in the flow.
 		const db = await getTestDatabase();
 		let submissionId: number;
 		let memberId: number;
@@ -63,7 +65,34 @@ test.describe("Submission Complete Lifecycle", () => {
 			await db.close();
 		}
 
-		// Step 2: Login as admin and approve the submission
+		// Step 2: Member confirms they brought the fish to a meeting.
+		// Without this, the submission stays in awaiting-final-submission and
+		// admins can't see it in the approval queue.
+		await login(page, TEST_USER);
+
+		await page.goto(`/submissions/${submissionId}`);
+		await page.waitForSelector("body");
+
+		const broughtToMeetingButton = page.locator('button:has-text("Confirm: Brought to Meeting")');
+		await broughtToMeetingButton.scrollIntoViewIfNeeded();
+		await broughtToMeetingButton.click();
+		await page.waitForLoadState("networkidle");
+
+		// Verify final_submission_on was set
+		const dbAfterFinalSubmit = await getTestDatabase();
+		try {
+			const submission = await dbAfterFinalSubmit.get(
+				"SELECT final_submission_on FROM submissions WHERE id = ?",
+				submissionId
+			);
+			expect(submission.final_submission_on).toBeTruthy();
+		} finally {
+			await dbAfterFinalSubmit.close();
+		}
+
+		await logout(page);
+
+		// Step 3: Login as admin and approve the submission
 		await login(page, TEST_ADMIN);
 
 		await page.goto(`/submissions/${submissionId}`);
@@ -137,13 +166,15 @@ test.describe("Submission Complete Lifecycle", () => {
 
 			adminId = admin.id;
 
-			// Create submission with witness confirmation, 70 days ago to satisfy waiting period
+			// Create submission already in the approval queue (witnessed past waiting
+			// period and submitter has clicked "Brought to Meeting")
 			submissionId = await createTestSubmission({
 				memberId: user.id,
 				submitted: true,
 				witnessed: true,
 				witnessedBy: admin.id,
 				witnessedDaysAgo: 70,
+				finalSubmitted: true,
 			});
 		} finally {
 			await db.close();
@@ -360,12 +391,15 @@ test.describe("Submission Complete Lifecycle", () => {
 
 			adminId = admin.id;
 
+			// Create submission already in the approval queue (witnessed past
+			// waiting period and submitter has clicked "Brought to Meeting")
 			submissionId = await createTestSubmission({
 				memberId: user.id,
 				submitted: true,
 				witnessed: true,
 				witnessedBy: admin.id,
 				witnessedDaysAgo: 70,
+				finalSubmitted: true,
 			});
 		} finally {
 			await db.close();
@@ -490,5 +524,123 @@ test.describe("Submission Complete Lifecycle", () => {
 		} finally {
 			await db3.close();
 		}
+	});
+});
+
+test.describe("Bring-to-Meeting (manual approval queue gating)", () => {
+	test.beforeEach(async () => {
+		await cleanupTestUserSubmissions(TEST_USER.email);
+		await ensureTestUserExists(TEST_USER.email, TEST_USER.password, TEST_USER.displayName, false);
+		await ensureTestUserExists(TEST_ADMIN.email, TEST_ADMIN.password, TEST_ADMIN.displayName, true);
+	});
+
+	test("witnessed-but-not-final-submitted submissions stay out of the admin queue until the submitter clicks; un-queue removes them again", async ({ page }) => {
+		const db = await getTestDatabase();
+		let submissionId: number;
+
+		try {
+			const user = await db.get<{ id: number }>(
+				"SELECT id FROM members WHERE contact_email = ?",
+				TEST_USER.email
+			);
+			const admin = await db.get<{ id: number }>(
+				"SELECT id FROM members WHERE contact_email = ?",
+				TEST_ADMIN.email
+			);
+
+			if (!user || !admin) {
+				throw new Error("Test users not found in database");
+			}
+
+			// Witnessed past the waiting period but no final_submission_on yet
+			submissionId = await createTestSubmission({
+				memberId: user.id,
+				submitted: true,
+				witnessed: true,
+				witnessedBy: admin.id,
+				witnessedDaysAgo: 70,
+				speciesCommonName: "Bring-to-Meeting Test Guppy",
+			});
+		} finally {
+			await db.close();
+		}
+
+		// Step 1: Admin queue should NOT contain this submission yet
+		await login(page, TEST_ADMIN);
+		await page.goto("/admin/queue/fish");
+		await page.waitForLoadState("networkidle");
+
+		const queueLinkBefore = page.locator(`a[href="/submissions/${submissionId}"]`);
+		await expect(queueLinkBefore).toHaveCount(0);
+
+		await logout(page);
+
+		// Step 2: Submitter sees the "Bring to Meeting" panel and clicks the button
+		await login(page, TEST_USER);
+		await page.goto(`/submissions/${submissionId}`);
+		await page.waitForSelector("body");
+
+		await expect(page.locator('h3:has-text("Bring to Meeting")')).toBeVisible();
+
+		const broughtToMeetingButton = page.locator('button:has-text("Confirm: Brought to Meeting")');
+		await broughtToMeetingButton.scrollIntoViewIfNeeded();
+		await broughtToMeetingButton.click();
+		await page.waitForLoadState("networkidle");
+
+		// final_submission_on is set
+		const dbAfterFinalSubmit = await getTestDatabase();
+		try {
+			const submission = await dbAfterFinalSubmit.get(
+				"SELECT final_submission_on FROM submissions WHERE id = ?",
+				submissionId
+			);
+			expect(submission.final_submission_on).toBeTruthy();
+		} finally {
+			await dbAfterFinalSubmit.close();
+		}
+
+		await logout(page);
+
+		// Step 3: Admin queue now contains the submission
+		await login(page, TEST_ADMIN);
+		await page.goto("/admin/queue/fish");
+		await page.waitForLoadState("networkidle");
+
+		const queueLinkAfter = page.locator(`a[href="/submissions/${submissionId}"]`);
+		await expect(queueLinkAfter).toHaveCount(1);
+
+		await logout(page);
+
+		// Step 4: Submitter un-queues
+		await login(page, TEST_USER);
+		await page.goto(`/submissions/${submissionId}`);
+		await page.waitForSelector("body");
+
+		page.on("dialog", (dialog) => dialog.accept());
+		const removeFromQueueButton = page.locator('button:has-text("Remove from Queue")');
+		await removeFromQueueButton.scrollIntoViewIfNeeded();
+		await removeFromQueueButton.click();
+		await page.waitForLoadState("networkidle");
+
+		const dbAfterUnqueue = await getTestDatabase();
+		try {
+			const submission = await dbAfterUnqueue.get(
+				"SELECT final_submission_on FROM submissions WHERE id = ?",
+				submissionId
+			);
+			expect(submission.final_submission_on).toBeNull();
+		} finally {
+			await dbAfterUnqueue.close();
+		}
+
+		await logout(page);
+
+		// Step 5: Admin queue is empty again
+		await login(page, TEST_ADMIN);
+		await page.goto("/admin/queue/fish");
+		await page.waitForLoadState("networkidle");
+
+		const queueLinkAfterUnqueue = page.locator(`a[href="/submissions/${submissionId}"]`);
+		await expect(queueLinkAfterUnqueue).toHaveCount(0);
 	});
 });

--- a/e2e/submission-status-display.spec.ts
+++ b/e2e/submission-status-display.spec.ts
@@ -44,7 +44,9 @@ test.describe("Changes-Requested Status Display", () => {
 			memberId = user.id;
 			adminId = admin.id;
 
-			// Create witnessed submission with changes requested
+			// Create witnessed submission already in the approval queue, then
+			// add changes_requested fields to simulate an admin requesting
+			// changes during review.
 			submissionId = await createTestSubmission({
 				memberId: user.id,
 				submitted: true,
@@ -52,6 +54,7 @@ test.describe("Changes-Requested Status Display", () => {
 				witnessedBy: admin.id,
 				witnessedDaysAgo: 70,
 				reproductionDaysAgo: 70,
+				finalSubmitted: true,
 			});
 
 			// Set changes_requested fields

--- a/src/__tests__/finalSubmission.test.ts
+++ b/src/__tests__/finalSubmission.test.ts
@@ -1,0 +1,265 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import {
+  setFinalSubmission,
+  clearFinalSubmission,
+  getSubmissionById,
+  getOutstandingSubmissions,
+} from "../db/submissions";
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+  createTestSubmission,
+  type TestContext,
+} from "./helpers/testHelpers";
+
+/**
+ * Tests for the manual final-submission step that gates the admin approval
+ * queue. After the waiting period elapses, a submission must have
+ * final_submission_on set (via the submitter or an admin clicking a button)
+ * before it shows up in the approval queue.
+ */
+
+const SIXTY_FIVE_DAYS_AGO = new Date(Date.now() - 65 * 24 * 60 * 60 * 1000).toISOString();
+const TEN_DAYS_AGO = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+void describe("Final Submission (Manual Approval Queue Gating)", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDatabase({ adminCount: 2 });
+  });
+
+  afterEach(async () => {
+    await teardownTestDatabase(ctx);
+  });
+
+  void describe("setFinalSubmission()", () => {
+    void test("owner can mark a confirmed past-waiting-period submission as final-submitted", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+
+      const submission = await getSubmissionById(submissionId);
+      assert.ok(submission?.final_submission_on, "final_submission_on should be set");
+    });
+
+    void test("admin can mark on submitter's behalf", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await setFinalSubmission(submissionId, ctx.admin.id, true);
+
+      const submission = await getSubmissionById(submissionId);
+      assert.ok(submission?.final_submission_on);
+    });
+
+    void test("non-owner non-admin is rejected", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await assert.rejects(
+        async () => await setFinalSubmission(submissionId, 99999, false),
+        /Cannot modify another member's submission/
+      );
+
+      const submission = await getSubmissionById(submissionId);
+      assert.strictEqual(submission?.final_submission_on, null);
+    });
+
+    void test("rejects when waiting period has not elapsed", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: TEN_DAYS_AGO,
+      });
+
+      await assert.rejects(
+        async () => await setFinalSubmission(submissionId, ctx.member.id, false),
+        /Waiting period has not elapsed/
+      );
+    });
+
+    void test("rejects when witness status is still pending", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "pending",
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await assert.rejects(
+        async () => await setFinalSubmission(submissionId, ctx.member.id, false),
+        /Submission has not been screened/
+      );
+    });
+
+    void test("rejects when submission is still a draft", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: false,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await assert.rejects(
+        async () => await setFinalSubmission(submissionId, ctx.member.id, false),
+        /Submission is still a draft/
+      );
+    });
+
+    void test("rejects when submission is already approved", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        approved: true,
+        approvedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await assert.rejects(
+        async () => await setFinalSubmission(submissionId, ctx.member.id, false),
+        /Submission already approved/
+      );
+    });
+
+    void test("is idempotent - calling twice does not change timestamp", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+      const first = await getSubmissionById(submissionId);
+      const firstTs = first?.final_submission_on;
+
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+      const second = await getSubmissionById(submissionId);
+
+      assert.strictEqual(second?.final_submission_on, firstTs);
+    });
+  });
+
+  void describe("clearFinalSubmission()", () => {
+    void test("owner can un-queue an unapproved submission", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+      await clearFinalSubmission(submissionId, ctx.member.id, false);
+
+      const submission = await getSubmissionById(submissionId);
+      assert.strictEqual(submission?.final_submission_on, null);
+    });
+
+    void test("rejects when submission is already approved", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        approved: true,
+        approvedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await assert.rejects(
+        async () => await clearFinalSubmission(submissionId, ctx.member.id, false),
+        /Submission already approved/
+      );
+    });
+
+    void test("non-owner non-admin is rejected", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+
+      await assert.rejects(
+        async () => await clearFinalSubmission(submissionId, 99999, false),
+        /Cannot modify another member's submission/
+      );
+
+      const submission = await getSubmissionById(submissionId);
+      assert.ok(submission?.final_submission_on);
+    });
+  });
+
+  void describe("Approval queue gating", () => {
+    void test("submissions past waiting period without final_submission_on are NOT in the queue", async () => {
+      await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      const queue = await getOutstandingSubmissions("fish");
+      assert.strictEqual(queue.length, 0, "queue should be empty until submitter clicks the button");
+    });
+
+    void test("submissions appear in the queue once final_submission_on is set", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+
+      const queue = await getOutstandingSubmissions("fish");
+      assert.strictEqual(queue.length, 1);
+      assert.strictEqual(queue[0].id, submissionId);
+    });
+
+    void test("clearing final_submission_on removes the submission from the queue", async () => {
+      const submissionId = await createTestSubmission(ctx.db, {
+        memberId: ctx.member.id,
+        submitted: true,
+        witnessStatus: "confirmed",
+        witnessedBy: ctx.admin.id,
+        reproductionDate: SIXTY_FIVE_DAYS_AGO,
+      });
+
+      await setFinalSubmission(submissionId, ctx.member.id, false);
+      await clearFinalSubmission(submissionId, ctx.member.id, false);
+
+      const queue = await getOutstandingSubmissions("fish");
+      assert.strictEqual(queue.length, 0);
+    });
+  });
+});

--- a/src/__tests__/submissionStatus.test.ts
+++ b/src/__tests__/submissionStatus.test.ts
@@ -18,6 +18,7 @@ void describe("Submission Status Calculation", () => {
     denied_on: null,
     denied_by: null,
     denied_reason: null,
+    final_submission_on: null,
   };
 
   void describe("Draft Status", () => {
@@ -183,10 +184,11 @@ void describe("Submission Status Calculation", () => {
   });
 
   void describe("Pending Approval Status", () => {
-    void test("should return pending-approval for witnessed submissions past waiting period", () => {
-      // Mock a submission that's been witnessed and past waiting period
+    void test("should return awaiting-final-submission for witnessed submissions past waiting period without final submission", () => {
+      // Past waiting period but submitter hasn't confirmed bringing the fish
+      // to a meeting yet, so it's not in the approval queue.
       const witnessedDate = new Date();
-      witnessedDate.setDate(witnessedDate.getDate() - 65); // 65 days ago (past 60-day waiting period)
+      witnessedDate.setDate(witnessedDate.getDate() - 65); // past 60-day waiting period
 
       const submission: Partial<Submission> = {
         ...baseSubmission,
@@ -195,6 +197,27 @@ void describe("Submission Status Calculation", () => {
         witnessed_on: witnessedDate.toISOString(),
         species_type: "Fish",
         reproduction_date: witnessedDate.toISOString(),
+        final_submission_on: null,
+      };
+
+      const status = getSubmissionStatus(submission);
+
+      assert.strictEqual(status.status, "awaiting-final-submission");
+      assert.strictEqual(status.label, "Bring to Meeting");
+    });
+
+    void test("should return pending-approval once submitter has marked final_submission_on", () => {
+      const witnessedDate = new Date();
+      witnessedDate.setDate(witnessedDate.getDate() - 65);
+
+      const submission: Partial<Submission> = {
+        ...baseSubmission,
+        submitted_on: witnessedDate.toISOString(),
+        witness_verification_status: "confirmed" as const,
+        witnessed_on: witnessedDate.toISOString(),
+        species_type: "Fish",
+        reproduction_date: witnessedDate.toISOString(),
+        final_submission_on: new Date().toISOString(),
       };
 
       const status = getSubmissionStatus(submission);

--- a/src/db/submissions.ts
+++ b/src/db/submissions.ts
@@ -3,6 +3,7 @@ import { FormValues } from "@/forms/submission";
 import { writeConn, query, withTransaction } from "./conn";
 import { logger } from "@/utils/logger";
 import { ValidationError, AuthorizationError, StateError } from "@/utils/errors";
+import { filterEligibleSubmissions, isEligibleForApproval } from "@/utils/waitingPeriod";
 import type { Database } from "sqlite";
 
 // New normalized table types
@@ -94,6 +95,8 @@ export type Submission = {
   changes_requested_on: string | null;
   changes_requested_by: number | null;
   changes_requested_reason: string | null;
+
+  final_submission_on: string | null;
 
   is_cares_species?: number | null;
 };
@@ -352,8 +355,6 @@ export function getApprovedSubmissionsInDateRange(startDate: Date, endDate: Date
 }
 
 export async function getOutstandingSubmissions(program: string) {
-  const { filterEligibleSubmissions } = await import("@/utils/waitingPeriod");
-
   const allWitnessed = await query<Submission>(
     `
 		SELECT
@@ -375,6 +376,7 @@ export async function getOutstandingSubmissions(program: string) {
 		WHERE submitted_on IS NOT NULL
 		AND approved_on IS NULL
 		AND witness_verification_status = 'confirmed'
+		AND final_submission_on IS NOT NULL
 		AND program = ?`,
     [program]
   );
@@ -433,6 +435,7 @@ export async function getOutstandingSubmissionsCounts() {
 		WHERE submitted_on IS NOT NULL
 		AND approved_on IS NULL
 		AND witness_verification_status = 'confirmed'
+		AND final_submission_on IS NOT NULL
 		GROUP BY program`);
   return Object.fromEntries(rows.map((row) => [row.program, row.count]));
 }
@@ -446,6 +449,135 @@ export async function getWitnessQueueCounts() {
 		AND witness_verification_status = 'pending'
 		GROUP BY program`);
   return Object.fromEntries(rows.map((row) => [row.program, row.count]));
+}
+
+/**
+ * Mark a submission as brought to a meeting and ready for the approval queue.
+ *
+ * Allowed when the caller is the submission owner or an admin, the submission
+ * has been screened (witness confirmed), the waiting period has elapsed, and
+ * the submission is not already approved or denied.
+ */
+export async function setFinalSubmission(
+  submissionId: number,
+  userId: number,
+  isAdmin: boolean
+): Promise<void> {
+  return await withTransaction(async (db) => {
+    const stmt = await db.prepare(`
+        SELECT id, member_id, submitted_on, witness_verification_status,
+               approved_on, denied_on, final_submission_on, reproduction_date,
+               species_type, species_class
+        FROM submissions WHERE id = ?`);
+    const current: Submission[] = await stmt.all(submissionId);
+    await stmt.finalize();
+
+    if (!current[0]) {
+      throw new ValidationError("Submission not found", "submissionId", submissionId);
+    }
+
+    const submission = current[0];
+
+    if (!isAdmin && submission.member_id !== userId) {
+      throw new AuthorizationError(
+        "Cannot modify another member's submission",
+        userId,
+        "set_final_submission"
+      );
+    }
+
+    if (!submission.submitted_on) {
+      throw new StateError("Submission is still a draft", "submitted", "draft");
+    }
+    if (submission.approved_on) {
+      throw new StateError("Submission already approved", "unapproved", "approved");
+    }
+    if (submission.denied_on) {
+      throw new StateError("Submission was denied", "unapproved", "denied");
+    }
+    if (submission.witness_verification_status !== "confirmed") {
+      throw new StateError(
+        "Submission has not been screened",
+        "confirmed",
+        submission.witness_verification_status
+      );
+    }
+    if (!isEligibleForApproval(submission)) {
+      throw new StateError(
+        "Waiting period has not elapsed",
+        "past_waiting_period",
+        "in_waiting_period"
+      );
+    }
+
+    if (submission.final_submission_on) {
+      return;
+    }
+
+    const updateStmt = await db.prepare(`
+        UPDATE submissions SET final_submission_on = ?
+        WHERE id = ? AND final_submission_on IS NULL AND approved_on IS NULL`);
+    const result = await updateStmt.run(new Date().toISOString(), submissionId);
+    await updateStmt.finalize();
+
+    if (result.changes === 0) {
+      throw new StateError("Submission state changed during operation", "queueable", "unknown");
+    }
+
+    logger.info("Submission queued for approval", { submissionId, userId, isAdmin });
+  });
+}
+
+/**
+ * Undo a final submission so the submission leaves the approval queue.
+ * Allowed for owner or admin while the submission is unapproved.
+ */
+export async function clearFinalSubmission(
+  submissionId: number,
+  userId: number,
+  isAdmin: boolean
+): Promise<void> {
+  return await withTransaction(async (db) => {
+    const stmt = await db.prepare(`
+        SELECT id, member_id, approved_on, denied_on, final_submission_on
+        FROM submissions WHERE id = ?`);
+    const current: Submission[] = await stmt.all(submissionId);
+    await stmt.finalize();
+
+    if (!current[0]) {
+      throw new ValidationError("Submission not found", "submissionId", submissionId);
+    }
+
+    const submission = current[0];
+
+    if (!isAdmin && submission.member_id !== userId) {
+      throw new AuthorizationError(
+        "Cannot modify another member's submission",
+        userId,
+        "clear_final_submission"
+      );
+    }
+
+    if (submission.approved_on) {
+      throw new StateError("Submission already approved", "unapproved", "approved");
+    }
+
+    if (!submission.final_submission_on) {
+      return;
+    }
+
+    const updateStmt = await db.prepare(`
+        UPDATE submissions SET final_submission_on = NULL
+        WHERE id = ? AND approved_on IS NULL`);
+    const result = await updateStmt.run(submissionId);
+    await updateStmt.finalize();
+
+    if (result.changes === 0) {
+      throw new StateError("Submission state changed during operation", "queued", "unknown");
+    }
+
+    logger.info("Submission removed from approval queue", { submissionId, userId, isAdmin });
+  });
 }
 
 export async function confirmWitness(submissionId: number, witnessAdminId: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,8 @@ router.get("/submissions/:id", submission.view);
 router.post("/submissions", submission.create);
 router.patch("/submissions/:id", submission.update);
 router.delete("/submissions/:id", submission.remove);
+router.post("/submissions/:id/final-submit", submission.finalSubmit);
+router.delete("/submissions/:id/final-submit", submission.unfinalSubmit);
 router.get("/submissions/:id/edit-media", submission.renderEditMedia);
 router.patch("/submissions/:id/media", submission.updateMedia);
 

--- a/src/routes/submission.ts
+++ b/src/routes/submission.ts
@@ -29,6 +29,7 @@ import {
 import { getSpeciesGroup, getGroupIdFromNameId } from "@/db/species";
 import { getWaitingPeriodStatus } from "@/utils/waitingPeriod";
 import { getNotesForSubmission } from "@/db/submission_notes";
+import { AuthorizationError, StateError, ValidationError } from "@/utils/errors";
 import { formatShortDate } from "@/utils/dateFormat";
 import { parseVideoUrlWithOEmbed, isValidVideoUrl } from "@/utils/videoParser";
 import config from "@/config.json";
@@ -230,6 +231,9 @@ export const view = async (req: MulmRequest, res: Response) => {
       submitted_on: formatShortDate(submission.submitted_on),
       witnessed_on: formatShortDate(submission.witnessed_on),
       approved_on: formatShortDate(submission.approved_on),
+      final_submission_on: submission.final_submission_on
+        ? formatShortDate(submission.final_submission_on)
+        : null,
       approved_by: approver?.display_name,
       witnessed:
         witness && submission.witnessed_on
@@ -491,6 +495,76 @@ export const remove = async (req: MulmRequest, res: Response) => {
 
   // Not authorized
   res.status(403).send("Cannot delete approved submissions");
+};
+
+export const finalSubmit = async (req: MulmRequest, res: Response) => {
+  const submission = await validateSubmission(req, res);
+  if (!submission) {
+    return;
+  }
+
+  const { viewer } = req;
+  if (!viewer) {
+    res.status(401).send();
+    return;
+  }
+
+  const isAdmin = Boolean(viewer.is_admin);
+  if (!isAdmin && viewer.id !== submission.member_id) {
+    res.status(403).send("Not authorized");
+    return;
+  }
+
+  try {
+    await db.setFinalSubmission(submission.id, viewer.id, isAdmin);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      res.status(403).send(err.message);
+      return;
+    }
+    if (err instanceof StateError || err instanceof ValidationError) {
+      res.status(400).send(err.message);
+      return;
+    }
+    throw err;
+  }
+
+  res.set("HX-Redirect", `/submissions/${submission.id}`).status(200).send();
+};
+
+export const unfinalSubmit = async (req: MulmRequest, res: Response) => {
+  const submission = await validateSubmission(req, res);
+  if (!submission) {
+    return;
+  }
+
+  const { viewer } = req;
+  if (!viewer) {
+    res.status(401).send();
+    return;
+  }
+
+  const isAdmin = Boolean(viewer.is_admin);
+  if (!isAdmin && viewer.id !== submission.member_id) {
+    res.status(403).send("Not authorized");
+    return;
+  }
+
+  try {
+    await db.clearFinalSubmission(submission.id, viewer.id, isAdmin);
+  } catch (err) {
+    if (err instanceof AuthorizationError) {
+      res.status(403).send(err.message);
+      return;
+    }
+    if (err instanceof StateError || err instanceof ValidationError) {
+      res.status(400).send(err.message);
+      return;
+    }
+    throw err;
+  }
+
+  res.set("HX-Redirect", `/submissions/${submission.id}`).status(200).send();
 };
 
 /**

--- a/src/utils/submissionStatus.ts
+++ b/src/utils/submissionStatus.ts
@@ -5,6 +5,7 @@ export type SubmissionStatus =
   | "draft"
   | "pending-witness"
   | "waiting-period"
+  | "awaiting-final-submission"
   | "pending-approval"
   | "changes-requested"
   | "approved"
@@ -99,6 +100,19 @@ export function getSubmissionStatus(submission: Partial<Submission>): StatusInfo
         daysRemaining: waitingPeriodStatus.daysRemaining,
       };
     }
+
+    // Past waiting period but submitter hasn't confirmed the fish was brought
+    // to a meeting yet, so it shouldn't be in the approval queue.
+    if (!submission.final_submission_on) {
+      return {
+        status: "awaiting-final-submission",
+        label: "Bring to Meeting",
+        color: "text-teal-800",
+        bgColor: "bg-teal-100",
+        rowColor: "bg-teal-50",
+        description: "Bring to a monthly meeting and confirm to enter the approval queue",
+      };
+    }
   }
 
   // Submissions ready for approval
@@ -135,6 +149,8 @@ function getStatusIcon(status: SubmissionStatus): string {
       return "👁️";
     case "waiting-period":
       return "⏳";
+    case "awaiting-final-submission":
+      return "🐟";
     case "pending-approval":
       return "🔵";
     case "changes-requested":

--- a/src/views/submission/review.pug
+++ b/src/views/submission/review.pug
@@ -189,8 +189,8 @@ html
                             type="button"
                         ) Delete
 
-        // Unified Admin Section (action panels + notes + edit button)
-        if isAdmin
+        // Unified Status / Action Section - visible to submitter and admins
+        if isAdmin || isSelf
             section.bg-gray-100
                 // Screening Actions Panel - only show for pending screening
                 if submission.witness_verification_status === 'pending'
@@ -202,7 +202,7 @@ html
                                 - const speciesText = submission.species_type === 'Plant' || submission.species_type === 'Coral' ? 'propagation' : 'spawn'
                                 p.text-yellow-700.mb-2= `Your ${speciesText} needs to be screened by a different program admin for completeness.`
                                 p.text-yellow-600.text-sm You cannot screen your own submissions. Please contact another admin to review this submission.
-                    else
+                    else if isAdmin
                         // Show screening action buttons for other admins
                         .status-panel.status-panel-admin#witnessPanel
                             .container.mx-auto.max-w-4xl
@@ -251,66 +251,92 @@ html
                                             hx-delete=`/submissions/${submission.id}`
                                             hx-confirm="Are you sure you want to permanently delete this submission? This cannot be undone."
                                         ) Delete
-                    else if isSelf
-                        // Show message for self-approval prevention
+                    else if !submission.final_submission_on
+                        // Past waiting period but submitter hasn't confirmed the fish was brought to a meeting yet
+                        - const speciesText = submission.species_type === 'Plant' || submission.species_type === 'Coral' ? 'propagation' : 'spawn'
+                        - const offspringText = submission.species_type === 'Plant' ? 'plants' : submission.species_type === 'Coral' ? 'corals' : 'fry'
                         .status-panel.status-panel-warning
                             .container.mx-auto.max-w-4xl
-                                h3.text-yellow-800.text-lg.font-semibold.mb-2 ✅ Ready for Points Award
+                                h3.text-yellow-800.text-lg.font-semibold.mb-2 🐟 Bring to Meeting
+                                p.text-yellow-700.mb-2= `This ${speciesText} is past its waiting period. Bring the ${offspringText} to a monthly meeting, then click below to enter the approval queue.`
+                                p.text-yellow-600.text-sm.mb-4 Until you confirm, admins won't see this submission in the approval queue.
+                                if isSelf || isAdmin
+                                    .flex.justify-center
+                                        form(hx-post=`/submissions/${submission.id}/final-submit`)
+                                            button.primary(type="submit")
+                                                if isAdmin && !isSelf
+                                                    | Confirm on Submitter's Behalf
+                                                else
+                                                    | Confirm: Brought to Meeting
+                    else if isSelf
+                        // Submitter (or admin viewing own submission) has confirmed and is now in the queue
+                        .status-panel.status-panel-warning
+                            .container.mx-auto.max-w-4xl
+                                h3.text-yellow-800.text-lg.font-semibold.mb-2 ✅ In Approval Queue
                                 - const speciesText = submission.species_type === 'Plant' || submission.species_type === 'Coral' ? 'propagation' : 'spawn'
-                                - const offspringText = submission.species_type === 'Plant' ? 'plants' : submission.species_type === 'Coral' ? 'corals' : 'fry'
-                                p.text-yellow-700.mb-2= `Your ${speciesText} is auction-eligible. Bring ${offspringText} to the next meeting to receive points!`
-                                p.text-yellow-600.text-sm You cannot award points to your own submissions. Please contact another admin at the meeting to complete the award process.
+                                p.text-yellow-700.mb-2= `Your ${speciesText} is in the approval queue and awaiting admin review.`
+                                p.text-yellow-600.text-sm.mb-4 You cannot award points to your own submissions. If you need to remove this from the queue (e.g. you weren't able to bring it to the meeting), use the button below.
+                                .flex.justify-center
+                                    form(hx-delete=`/submissions/${submission.id}/final-submit` hx-confirm="Remove this submission from the approval queue? You can re-queue it later.")
+                                        button.destructive(type="submit") Remove from Queue
                     else
-                        // Show approval panel for other admins
+                        // Admin viewing someone else's queued submission - show approval panel
                         .status-panel.status-panel-admin#adminPanel
                             include ../admin/approvalPanel.pug
+                        .status-panel.status-panel-admin
+                            .container.mx-auto.max-w-4xl
+                                p.text-white.text-sm.mb-2 Submitter confirmed this was brought to a meeting on #{submission.final_submission_on}.
+                                .flex.justify-center
+                                    form(hx-delete=`/submissions/${submission.id}/final-submit` hx-confirm="Remove this submission from the approval queue?")
+                                        button.destructive(type="submit") Remove from Queue
 
             // Admin Notes and Actions - shown after action panels
-            section.bg-gray-700.py-6
-                div.max-w-4xl.mx-auto.text-left.px-4
-                    h2.text-xl.font-bold.mb-2.text-white Admin Section
-                    p.text-sm.text-gray-300.mb-4 Private notes and actions visible only to program admins
+            if isAdmin
+                section.bg-gray-700.py-6
+                    div.max-w-4xl.mx-auto.text-left.px-4
+                        h2.text-xl.font-bold.mb-2.text-white Admin Section
+                        p.text-sm.text-gray-300.mb-4 Private notes and actions visible only to program admins
 
-                    // Edit Approved Submission button (for approved submissions only)
-                    if isApproved && !isSelf
-                        div.mb-6
-                            button.primary(
-                                type="button"
-                                onclick="document.getElementById('edit-approved-dialog').showModal()"
-                                hx-get=`/admin/submissions/${submission.id}/edit-approved`
-                                hx-target="#edit-approved-dialog"
-                                hx-swap="innerHTML"
-                            ) Edit Approved Submission
+                        // Edit Approved Submission button (for approved submissions only)
+                        if isApproved && !isSelf
+                            div.mb-6
+                                button.primary(
+                                    type="button"
+                                    onclick="document.getElementById('edit-approved-dialog').showModal()"
+                                    hx-get=`/admin/submissions/${submission.id}/edit-approved`
+                                    hx-target="#edit-approved-dialog"
+                                    hx-swap="innerHTML"
+                                ) Edit Approved Submission
 
-                    // Notes subsection
-                    div.mt-6
-                        h3.text-lg.font-semibold.text-white.mb-2 Notes
+                        // Notes subsection
+                        div.mt-6
+                            h3.text-lg.font-semibold.text-white.mb-2 Notes
 
-                        //- Notes feed
-                        div#notes-list.mb-6.space-y-3
-                            if adminNotes && adminNotes.length > 0
-                                each note in adminNotes
-                                    include ../admin/submissionNote.pug
-                            else
-                                +emptyState("No notes yet", { size: "sm" })
+                            //- Notes feed
+                            div#notes-list.mb-6.space-y-3
+                                if adminNotes && adminNotes.length > 0
+                                    each note in adminNotes
+                                        include ../admin/submissionNote.pug
+                                else
+                                    +emptyState("No notes yet", { size: "sm" })
 
-                        //- Note form
-                        form#note-form(
-                            hx-post=`/admin/submissions/${submission.id}/notes`
-                            hx-target="#notes-list"
-                            hx-swap="beforeend"
-                            hx-on--after-request="this.reset()"
-                        )
-                            div.mb-2
-                                textarea.text-input(
-                                    id="note_text"
-                                    name="note_text"
-                                    placeholder="Write a note..."
-                                    rows="3"
-                                    required
-                                    maxlength="2000"
-                                )
-                            button.primary(type="submit") Add Note
+                            //- Note form
+                            form#note-form(
+                                hx-post=`/admin/submissions/${submission.id}/notes`
+                                hx-target="#notes-list"
+                                hx-swap="beforeend"
+                                hx-on--after-request="this.reset()"
+                            )
+                                div.mb-2
+                                    textarea.text-input(
+                                        id="note_text"
+                                        name="note_text"
+                                        placeholder="Write a note..."
+                                        rows="3"
+                                        required
+                                        maxlength="2000"
+                                    )
+                                button.primary(type="submit") Add Note
 
         // Initialize typeahead for species selection in approval panel
         if isAdmin


### PR DESCRIPTION
After the waiting period elapses, a submission no longer auto-promotes
into the admin approval queue. The submitter (or an admin on their
behalf) must click "Brought to Meeting" to set final_submission_on, and
they can un-queue any time before approval. This keeps the approval
queue limited to fish actually brought to a monthly meeting.

- Migration 053 adds final_submission_on, backfilled to approved_on for
  already-approved rows so historical data and admin views are unchanged
- New status: awaiting-final-submission, sits between waiting-period
  and pending-approval
- getOutstandingSubmissions and its count now require final_submission_on
- New POST/DELETE /submissions/:id/final-submit routes (owner or admin)
- Submitter-facing status panels and buttons in the review page