### PR TITLE
Responsive mobile nav with hamburger + slide-out

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) sessions; locally the user
+# manages their own node_modules.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install npm dependencies so lint, tests, and the dev server work.
+# Skip Husky's prepare hook (it's a no-op without git hooks dir setup) and
+# Playwright browser download (only needed for E2E, large, slow).
+HUSKY=0 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --no-audit --no-fund
+
+# Tests and the app import "@/config.json"; create a stub from the sample
+# if one doesn't already exist so type-checking and tests can resolve it.
+if [ ! -f src/config.json ] && [ -f src/config.sample.json ]; then
+  cp src/config.sample.json src/config.json
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .env
 .claude/*
 !.claude/skills/
+!.claude/hooks/
+!.claude/settings.json
 
 node_modules/
 dist/

--- a/src/views/header.pug
+++ b/src/views/header.pug
@@ -34,16 +34,17 @@ mixin headTag(title, ogData)
 
 mixin pageHeader(loggedIn, title, subtitle, trophyData, trophyUniqueId)
 	header.bg-white.shadow
-		div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center
-			.flex.text-center.gap-2.items-center
-				h2.text-2xl.font-bold.p2= title
-				if trophyUniqueId
-					+trophyWithHover(trophyData, trophyUniqueId)
-				else
-					+trophy(trophyData)
+		div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center.gap-4
+			.flex.flex-col.md:flex-row.md:text-center.gap-1.md:gap-2.md:items-center.min-w-0.flex-1
+				.flex.items-center.gap-2.min-w-0
+					h2.text-xl.md:text-2xl.font-bold.p2.truncate= title
+					if trophyUniqueId
+						+trophyWithHover(trophyData, trophyUniqueId)
+					else
+						+trophy(trophyData)
 				if subtitle
-					h3.text-2xl.p2(class="text-gray-500")= subtitle
-			.space-x-4.flex.items-center
+					h3.text-base.md:text-2xl.p2.truncate(class="text-gray-500")= subtitle
+			nav.hidden.md:flex.space-x-4.items-center
 				a.link(href="/") Home
 				a.link(href="/species") Species
 				a.link(href="/cares") CARES
@@ -52,6 +53,32 @@ mixin pageHeader(loggedIn, title, subtitle, trophyData, trophyUniqueId)
 				a.link(href=`mailto:${bugReportEmail}` title="Report a bug") 🐛
 				if loggedIn
 					a.link(href="/account") ⚙️
+			button.md:hidden.p-2.text-gray-700.hover:text-black.flex-shrink-0.cursor-pointer(
+				type="button"
+				aria-label="Open menu"
+				hx-on:click="document.getElementById('mobileNav').classList.remove('hidden')"
+			)
+				svg(xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7")
+					path(stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5")
+		.hidden.fixed.inset-0.z-50.bg-black/50.md:hidden#mobileNav(
+			hx-on:click="document.getElementById('mobileNav').classList.add('hidden')"
+		)
+			.absolute.top-0.right-0.h-screen.w-72.max-w-[80vw].bg-white.shadow-lg.flex.flex-col.p-4.gap-1(
+				hx-on:click="event.stopPropagation()"
+			)
+				button.self-end.p-2.text-3xl.leading-none.text-gray-500.hover:text-black.cursor-pointer(
+					type="button"
+					aria-label="Close menu"
+					hx-on:click="document.getElementById('mobileNav').classList.add('hidden')"
+				) &times;
+				a.link.text-lg.py-3.border-b.border-gray-100(href="/") Home
+				a.link.text-lg.py-3.border-b.border-gray-100(href="/species") Species
+				a.link.text-lg.py-3.border-b.border-gray-100(href="/cares") CARES
+				if loggedIn
+					a.link.text-lg.py-3.border-b.border-gray-100(href="/me") Me
+				a.link.text-lg.py-3.border-b.border-gray-100(href=`mailto:${bugReportEmail}`) 🐛 Report a bug
+				if loggedIn
+					a.link.text-lg.py-3(href="/account") ⚙️ Account
 
 mixin footer()
 	footer.bg-gray-300.py-6.text-center.text-sm.text-gray-500

--- a/src/views/header.pug
+++ b/src/views/header.pug
@@ -32,6 +32,49 @@ mixin headTag(title, ogData)
 
 		block
 
+mixin navMenu(loggedIn)
+	nav.space-x-4.items-center(class="hidden md:flex")
+		a.link(href="/") Home
+		a.link(href="/species") Species
+		a.link(href="/cares") CARES
+		if loggedIn
+			a.link(href="/me") Me
+		a.link(href=`mailto:${bugReportEmail}` title="Report a bug") 🐛
+		if loggedIn
+			a.link(href="/account") ⚙️
+	a.p-2.flex-shrink-0.cursor-pointer(
+		href="#"
+		role="button"
+		class="md:hidden text-gray-700 hover:text-black"
+		aria-label="Open menu"
+		hx-on:click="event.preventDefault(); document.getElementById('mobileNav').classList.remove('hidden')"
+	)
+		svg(xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7")
+			path(stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5")
+	div#mobileNav.hidden.fixed.inset-0.z-50(
+		class="md:hidden bg-black/50"
+		hx-on:click="document.getElementById('mobileNav').classList.add('hidden')"
+	)
+		div.absolute.top-0.right-0.h-screen.w-72.bg-white.shadow-lg.flex.flex-col.p-4.gap-1(
+			class="max-w-[80vw]"
+			hx-on:click="event.stopPropagation()"
+		)
+			a.self-end.p-2.text-3xl.leading-none.cursor-pointer.font-bold(
+				href="#"
+				role="button"
+				class="text-gray-500 hover:text-black"
+				aria-label="Close menu"
+				hx-on:click="event.preventDefault(); document.getElementById('mobileNav').classList.add('hidden')"
+			) &times;
+			a.link.text-lg.py-3.border-b.border-gray-100(href="/") Home
+			a.link.text-lg.py-3.border-b.border-gray-100(href="/species") Species
+			a.link.text-lg.py-3.border-b.border-gray-100(href="/cares") CARES
+			if loggedIn
+				a.link.text-lg.py-3.border-b.border-gray-100(href="/me") Me
+			a.link.text-lg.py-3.border-b.border-gray-100(href=`mailto:${bugReportEmail}`) 🐛 Report a bug
+			if loggedIn
+				a.link.text-lg.py-3(href="/account") ⚙️ Account
+
 mixin pageHeader(loggedIn, title, subtitle, trophyData, trophyUniqueId)
 	header.bg-white.shadow
 		div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center.gap-4
@@ -44,47 +87,7 @@ mixin pageHeader(loggedIn, title, subtitle, trophyData, trophyUniqueId)
 						+trophy(trophyData)
 				if subtitle
 					h3.p2.truncate(class="text-base md:text-2xl text-gray-500")= subtitle
-			nav.space-x-4.items-center(class="hidden md:flex")
-				a.link(href="/") Home
-				a.link(href="/species") Species
-				a.link(href="/cares") CARES
-				if loggedIn
-					a.link(href="/me") Me
-				a.link(href=`mailto:${bugReportEmail}` title="Report a bug") 🐛
-				if loggedIn
-					a.link(href="/account") ⚙️
-			a.p-2.flex-shrink-0.cursor-pointer(
-				href="#"
-				role="button"
-				class="md:hidden text-gray-700 hover:text-black"
-				aria-label="Open menu"
-				hx-on:click="event.preventDefault(); document.getElementById('mobileNav').classList.remove('hidden')"
-			)
-				svg(xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7")
-					path(stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5")
-		div#mobileNav.hidden.fixed.inset-0.z-50(
-			class="md:hidden bg-black/50"
-			hx-on:click="document.getElementById('mobileNav').classList.add('hidden')"
-		)
-			div.absolute.top-0.right-0.h-screen.w-72.bg-white.shadow-lg.flex.flex-col.p-4.gap-1(
-				class="max-w-[80vw]"
-				hx-on:click="event.stopPropagation()"
-			)
-				a.self-end.p-2.text-3xl.leading-none.cursor-pointer.font-bold(
-					href="#"
-					role="button"
-					class="text-gray-500 hover:text-black"
-					aria-label="Close menu"
-					hx-on:click="event.preventDefault(); document.getElementById('mobileNav').classList.add('hidden')"
-				) &times;
-				a.link.text-lg.py-3.border-b.border-gray-100(href="/") Home
-				a.link.text-lg.py-3.border-b.border-gray-100(href="/species") Species
-				a.link.text-lg.py-3.border-b.border-gray-100(href="/cares") CARES
-				if loggedIn
-					a.link.text-lg.py-3.border-b.border-gray-100(href="/me") Me
-				a.link.text-lg.py-3.border-b.border-gray-100(href=`mailto:${bugReportEmail}`) 🐛 Report a bug
-				if loggedIn
-					a.link.text-lg.py-3(href="/account") ⚙️ Account
+			+navMenu(loggedIn)
 
 mixin footer()
 	footer.bg-gray-300.py-6.text-center.text-sm.text-gray-500

--- a/src/views/header.pug
+++ b/src/views/header.pug
@@ -35,16 +35,16 @@ mixin headTag(title, ogData)
 mixin pageHeader(loggedIn, title, subtitle, trophyData, trophyUniqueId)
 	header.bg-white.shadow
 		div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center.gap-4
-			.flex.flex-col.md:flex-row.md:text-center.gap-1.md:gap-2.md:items-center.min-w-0.flex-1
+			div(class="flex flex-col md:flex-row md:text-center gap-1 md:gap-2 md:items-center min-w-0 flex-1")
 				.flex.items-center.gap-2.min-w-0
-					h2.text-xl.md:text-2xl.font-bold.p2.truncate= title
+					h2.font-bold.p2.truncate(class="text-xl md:text-2xl")= title
 					if trophyUniqueId
 						+trophyWithHover(trophyData, trophyUniqueId)
 					else
 						+trophy(trophyData)
 				if subtitle
-					h3.text-base.md:text-2xl.p2.truncate(class="text-gray-500")= subtitle
-			nav.hidden.md:flex.space-x-4.items-center
+					h3.p2.truncate(class="text-base md:text-2xl text-gray-500")= subtitle
+			nav.space-x-4.items-center(class="hidden md:flex")
 				a.link(href="/") Home
 				a.link(href="/species") Species
 				a.link(href="/cares") CARES
@@ -53,23 +53,29 @@ mixin pageHeader(loggedIn, title, subtitle, trophyData, trophyUniqueId)
 				a.link(href=`mailto:${bugReportEmail}` title="Report a bug") 🐛
 				if loggedIn
 					a.link(href="/account") ⚙️
-			button.md:hidden.p-2.text-gray-700.hover:text-black.flex-shrink-0.cursor-pointer(
-				type="button"
+			a.p-2.flex-shrink-0.cursor-pointer(
+				href="#"
+				role="button"
+				class="md:hidden text-gray-700 hover:text-black"
 				aria-label="Open menu"
-				hx-on:click="document.getElementById('mobileNav').classList.remove('hidden')"
+				hx-on:click="event.preventDefault(); document.getElementById('mobileNav').classList.remove('hidden')"
 			)
 				svg(xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7")
 					path(stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5")
-		.hidden.fixed.inset-0.z-50.bg-black/50.md:hidden#mobileNav(
+		div#mobileNav.hidden.fixed.inset-0.z-50(
+			class="md:hidden bg-black/50"
 			hx-on:click="document.getElementById('mobileNav').classList.add('hidden')"
 		)
-			.absolute.top-0.right-0.h-screen.w-72.max-w-[80vw].bg-white.shadow-lg.flex.flex-col.p-4.gap-1(
+			div.absolute.top-0.right-0.h-screen.w-72.bg-white.shadow-lg.flex.flex-col.p-4.gap-1(
+				class="max-w-[80vw]"
 				hx-on:click="event.stopPropagation()"
 			)
-				button.self-end.p-2.text-3xl.leading-none.text-gray-500.hover:text-black.cursor-pointer(
-					type="button"
+				a.self-end.p-2.text-3xl.leading-none.cursor-pointer.font-bold(
+					href="#"
+					role="button"
+					class="text-gray-500 hover:text-black"
 					aria-label="Close menu"
-					hx-on:click="document.getElementById('mobileNav').classList.add('hidden')"
+					hx-on:click="event.preventDefault(); document.getElementById('mobileNav').classList.add('hidden')"
 				) &times;
 				a.link.text-lg.py-3.border-b.border-gray-100(href="/") Home
 				a.link.text-lg.py-3.border-b.border-gray-100(href="/species") Species

--- a/src/views/member/collection.pug
+++ b/src/views/member/collection.pug
@@ -10,20 +10,13 @@ html
 	body.bg-gray-50.text-gray-800
 		//- Custom header with back link
 		header.bg-white.shadow
-			div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center
-				.flex.items-center.gap-4
-					a.text-blue-600.hover_text-blue-800.text-2xl.font-bold(href=`/member/${member.id}` title="Back to Profile") ←
-					.flex.items-center.gap-2
-						h2.text-2xl.font-bold= `${member.display_name}'s Collection`
+			div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center.gap-4
+				.flex.items-center.gap-2.min-w-0.flex-1
+					a.text-blue-600.hover_text-blue-800.text-2xl.font-bold.flex-shrink-0(href=`/member/${member.id}` title="Back to Profile") ←
+					.flex.items-center.gap-2.min-w-0
+						h2.font-bold.truncate(class="text-xl md:text-2xl")= `${member.display_name}'s Collection`
 						+trophyWithHover(trophyData, member.id)
-				.space-x-4.flex.items-center
-					a.link(href="/") Home
-					a.link(href="/species") Species
-					if isLoggedIn
-						a.link(href="/me") Me
-					a.link(href=`mailto:${bugReportEmail}` title="Report a bug") 🐛
-					if isLoggedIn
-						a.link(href="/account") ⚙️
+				+navMenu(isLoggedIn)
 
 		main.max-w-7xl.mx-auto.px-4.py-8(class="sm:px-6 lg:px-8")
 

--- a/src/views/submission/review.pug
+++ b/src/views/submission/review.pug
@@ -21,23 +21,16 @@ html
 
     body.bg-white.text-gray-800
         header.bg-white.shadow
-            div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center
-                .flex.text-center.gap-2.items-center
+            div.max-w-7xl.mx-auto.px-4.py-4.flex.justify-between.items-center.gap-4
+                div(class="flex flex-col md:flex-row md:text-center gap-1 md:gap-2 md:items-center min-w-0 flex-1")
                     if name && name.group_id
-                        a.link(href=`/species/${name.group_id}`)
-                            h2.text-2xl.font-bold.p2= canonicalName
+                        a.link.min-w-0(href=`/species/${name.group_id}`)
+                            h2.font-bold.p2.truncate(class="text-xl md:text-2xl")= canonicalName
                     else
-                        h2.text-2xl.font-bold.p2= canonicalName
-                    a.link(href=`/member/${submission.member_id}`)
-                        h3.text-2xl.p2(class="text-gray-500")= submission.member_name
-                .space-x-4.flex.items-center
-                    a.link(href="/") Home
-                    a.link(href="/species") Species
-                    if isLoggedIn
-                        a.link(href="/me") Me
-                    a.link(href=`mailto:${bugReportEmail}` title="Report a bug") 🐛
-                    if isLoggedIn
-                        a.link(href="/account") ⚙️
+                        h2.font-bold.p2.truncate.min-w-0(class="text-xl md:text-2xl")= canonicalName
+                    a.link.min-w-0(href=`/member/${submission.member_id}`)
+                        h3.p2.truncate(class="text-base md:text-2xl text-gray-500")= submission.member_name
+                +navMenu(isLoggedIn)
 
         section.bg-gray-100.py-4
 


### PR DESCRIPTION
## Summary

The page header was a single non-wrapping flex row, so on narrow viewports the title, member name, and nav links overflowed and forced horizontal page scroll. This redesign keeps the desktop layout untouched and gives mobile a proper treatment.

- **Mobile (<md):** title and member name stack vertically (each gets the full width and truncates if needed), a hamburger icon on the right opens a slide-out panel with the nav links. Tapping the dim backdrop or the × closes it. Toggle uses HTMX `hx-on:click` — no custom JS file.
- **Desktop (md and up):** unchanged — title + member name inline, all nav links inline on the right.
- Hamburger and close controls are `<a role="button" hx-on:click=…>` (matching the existing pattern in the `dialog` mixin), because the global `button { display: flex }` rule in `src/index.css:28` sits outside any `@layer` and would otherwise override Tailwind responsive utilities like `md:hidden`.

Also adds a SessionStart hook (`.claude/hooks/session-start.sh`) so future Claude Code on the web sessions auto-install dependencies — without it, eslint, the test runner, and pug aren't available in fresh sandboxes.

## Test plan

- [ ] Open a submission detail page on a phone (or DevTools device mode at 390×844): confirm no horizontal scroll, title and member name are on separate lines, hamburger is in the top-right.
- [ ] Tap the hamburger: slide-out appears from the right with Home / Species / CARES / Me / Report a bug / Account.
- [ ] Tap the dim backdrop and the ×: both close the panel.
- [ ] Tap a link in the panel: navigates to the page (panel naturally resets on page load).
- [ ] Resize to ≥768px: hamburger disappears, original desktop nav layout shows.
- [ ] Spot-check other pages that use `+pageHeader` (home, species detail, member, account) to confirm nothing regressed.

https://claude.ai/code/session_019Xf89MrAAS5WSNbLe7kAo6


---
_Generated by [Claude Code](https://claude.ai/code/session_019Xf89MrAAS5WSNbLe7kAo6)_