### PR TITLE
deps: bundle 8 transitive dependabot bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2522,15 +2522,15 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-cms": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
-			"integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+			"integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
-				"@peculiar/asn1-x509-attr": "^2.6.0",
-				"asn1js": "^3.0.6",
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-x509-attr": "^2.8.0",
+				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
@@ -2547,14 +2547,14 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-ecc": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.5.0.tgz",
-			"integrity": "sha512-t4eYGNhXtLRxaP50h3sfO6aJebUCDGQACoeexcelL4roMFRRVgB20yBIu2LxsPh/tdW9I282gNgMOyg3ywg/mg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+			"integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.5.0",
-				"@peculiar/asn1-x509": "^2.5.0",
-				"asn1js": "^3.0.6",
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
@@ -2613,37 +2613,46 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-schema": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-			"integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+			"integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
 			"license": "MIT",
 			"dependencies": {
-				"asn1js": "^3.0.6",
-				"pvtsutils": "^1.3.6",
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-x509": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
-			"integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+			"integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.6.0",
-				"asn1js": "^3.0.6",
-				"pvtsutils": "^1.3.6",
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.10",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-x509-attr": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
-			"integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+			"integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
-				"asn1js": "^3.0.6",
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+			"integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+			"license": "MIT",
+			"dependencies": {
 				"tslib": "^2.8.1"
 			}
 		},
@@ -2716,12 +2725,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "4.2.7",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
-			"integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.3.0.tgz",
+			"integrity": "sha512-u3id1QgrXUgDv9Mb5v8KzDqicHBdPSIL1nl+psna6DKkkwqg7PIC4Ig0LYT3qVsIAAnreOSrrUoLnFTanCMI3w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.11.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2771,20 +2780,13 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.0.tgz",
-			"integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+			"integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.7",
-				"@smithy/types": "^4.11.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.7",
-				"@smithy/util-stream": "^4.5.8",
-				"@smithy/util-utf8": "^4.2.0",
-				"@smithy/uuid": "^1.1.0",
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3057,12 +3059,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
-			"integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.4.2.tgz",
+			"integrity": "sha512-yWvlZxqgmk0ZiRd0QVzSAqvdkREeiw2boqT+DTbyi03ylx3LyYGs5hNvRjks5ay0cDotZ7H0AdG2tJDMy+IxgA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.11.0",
+				"@smithy/core": "^3.26.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3216,9 +3218,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
-			"integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+			"integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3410,11 +3412,12 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.4.2.tgz",
+			"integrity": "sha512-S3XyIjWOjXsSIJCTeZKpHN/3OqNmcZPqb0wMUrHM7JiTTmWc/PNT0i8n8v1W2zhpa7NJrC3MMreHVU5RJat/pQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@smithy/core": "^3.26.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3442,18 +3445,6 @@
 			"dependencies": {
 				"@smithy/abort-controller": "^4.2.7",
 				"@smithy/types": "^4.11.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/uuid": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-			"integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
-			"license": "Apache-2.0",
-			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4575,13 +4566,13 @@
 			"license": "MIT"
 		},
 		"node_modules/asn1js": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
-			"integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+			"integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"pvtsutils": "^1.3.6",
-				"pvutils": "^1.1.3",
+				"pvutils": "^1.1.5",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -8119,9 +8110,9 @@
 			}
 		},
 		"node_modules/node-abi": {
-			"version": "3.75.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-			"integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+			"version": "3.92.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+			"integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -9294,25 +9285,29 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-			"integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.5",
+				"debug": "^4.4.3",
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
 				"etag": "^1.8.1",
 				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"mime-types": "^3.0.1",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
 				"ms": "^2.1.3",
 				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
-				"statuses": "^2.0.1"
+				"statuses": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/send/node_modules/encodeurl": {
@@ -9333,6 +9328,26 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/send/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/send/node_modules/mime-db": {
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -9343,15 +9358,28 @@
 			}
 		},
 		"node_modules/send/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/send/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/serve-static": {


### PR DESCRIPTION
Bundles the 8 safe **transitive** dependency bumps that dependabot had open as individual PRs (#309–#316). After #333 rewrote `package-lock.json` (removing `aws-cdk-lib`), those March PRs all went conflicting; this re-applies them in one lockfile update via `npm update`.

| package | from | to |
|---|---|---|
| send | 1.2.0 | 1.2.1 |
| node-abi | 3.75.0 | 3.92.0 |
| @smithy/abort-controller | 4.2.7 | 4.3.0 |
| @smithy/types | 4.11.0 | 4.15.0 |
| @smithy/util-uri-escape | 4.2.0 | 4.4.2 |
| @smithy/middleware-stack | 4.2.7 | 4.4.2 |
| @peculiar/asn1-ecc | 2.5.0 | 2.8.0 |
| @peculiar/asn1-cms | 2.6.0 | 2.8.0 |

All minor/patch, lockfile-only (no `package.json` change). `npm update` landed them at-or-above the dependabot targets.

**Excludes** `zod` (#308): a 3→4 **major** used directly across 18 files (~189 validation sites) — needs a real migration pass, handled separately.

## Verification
- `npm run lint` — clean
- `npm test` — passes except `gbif-integration` / `wikipedia-integration` (live external-API suites, skipped in CI; pre-existing)

Supersedes #309, #310, #311, #312, #313, #314, #315, #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)