### PR TITLE
deps: migrate to zod 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1166,10 +1166,33 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/runtime": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
 			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -3843,7 +3866,6 @@
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
 			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -3913,7 +3935,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
 			"integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -4045,7 +4066,6 @@
 			"integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.62.0",
 				"@typescript-eslint/types": "8.62.0",
@@ -4295,7 +4315,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4819,7 +4838,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.38",
 				"caniuse-lite": "^1.0.30001799",
@@ -5858,7 +5876,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6126,7 +6143,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
 			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.0",
@@ -8533,7 +8549,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -10027,7 +10042,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -10165,7 +10179,6 @@
 			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -10247,7 +10260,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -10637,7 +10649,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"sqlite": "^5.1.1",
 				"sqlite3": "^5.1.7",
 				"uuid": "^13.0.0",
-				"zod": "^3.24.2"
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.2",
@@ -2442,15 +2442,6 @@
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"license": "MIT"
 		},
-		"node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
 		"node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
 			"version": "3.25.0",
 			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
@@ -3583,9 +3574,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3603,9 +3591,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3623,9 +3608,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3643,9 +3625,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3683,27 +3662,6 @@
 			},
 			"engines": {
 				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -3885,6 +3843,7 @@
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
 			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -3954,6 +3913,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
 			"integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -4085,6 +4045,7 @@
 			"integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.62.0",
 				"@typescript-eslint/types": "8.62.0",
@@ -4334,6 +4295,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4857,6 +4819,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.38",
 				"caniuse-lite": "^1.0.30001799",
@@ -5895,6 +5858,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6162,6 +6126,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
 			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.0",
@@ -8568,6 +8533,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -10061,6 +10027,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -10198,6 +10165,7 @@
 			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -10279,6 +10247,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -10664,10 +10633,11 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.24.2",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"sqlite": "^5.1.1",
 		"sqlite3": "^5.1.7",
 		"uuid": "^13.0.0",
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.39.2",

--- a/src/forms/cares.ts
+++ b/src/forms/cares.ts
@@ -7,8 +7,10 @@ import * as z from "zod";
 export const caresRegistrationSchema = z.object({
   collection_entry_id: z.coerce
     .number({
-      required_error: "Collection entry ID is required",
-      invalid_type_error: "Collection entry ID must be a number",
+      error: (iss) =>
+        iss.input === undefined
+          ? "Collection entry ID is required"
+          : "Collection entry ID must be a number",
     })
     .int()
     .positive("Collection entry ID must be positive"),
@@ -21,11 +23,11 @@ export type CaresRegistrationInput = z.infer<typeof caresRegistrationSchema>;
  */
 export const caresFryShareSchema = z.object({
   species_group_id: z.coerce
-    .number({ required_error: "Species is required" })
+    .number({ error: "Species is required" })
     .int()
     .positive("Please select a species"),
   recipient_name: z
-    .string({ required_error: "Recipient name is required" })
+    .string({ error: "Recipient name is required" })
     .min(1, "Recipient name is required")
     .max(200, "Recipient name is too long"),
   recipient_club: z
@@ -34,7 +36,7 @@ export const caresFryShareSchema = z.object({
     .optional()
     .transform((v) => (v && v.trim() ? v.trim() : null)),
   share_date: z
-    .string({ required_error: "Date is required" })
+    .string({ error: "Date is required" })
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format"),
   notes: z
     .string()

--- a/src/forms/collection.ts
+++ b/src/forms/collection.ts
@@ -120,7 +120,7 @@ export const collectionViewSchema = z.object({
     .string()
     .optional()
     .transform((val) => val === "true" || val === "1")
-    .default("false"),
+    .default(false),
 });
 
 /**
@@ -129,8 +129,8 @@ export const collectionViewSchema = z.object({
 export const memberIdParamSchema = z.object({
   memberId: z.coerce
     .number({
-      required_error: "Member ID is required",
-      invalid_type_error: "Member ID must be a number",
+      error: (iss) =>
+        iss.input === undefined ? "Member ID is required" : "Member ID must be a number",
     })
     .int()
     .positive("Member ID must be positive"),
@@ -139,8 +139,8 @@ export const memberIdParamSchema = z.object({
 export const entryIdParamSchema = z.object({
   id: z.coerce
     .number({
-      required_error: "Entry ID is required",
-      invalid_type_error: "Entry ID must be a number",
+      error: (iss) =>
+        iss.input === undefined ? "Entry ID is required" : "Entry ID must be a number",
     })
     .int()
     .positive("Entry ID must be positive"),

--- a/src/forms/login.ts
+++ b/src/forms/login.ts
@@ -14,10 +14,10 @@ export const signupSchema = z
     password: z
       .string()
       .max(100, "Password too long (max 100 characters)")
-      .refine(
-        (val) => validatePasswordComplexity(val).valid,
-        (val) => ({ message: validatePasswordComplexity(val).errors[0] || "Invalid password" })
-      ),
+      .refine((val) => validatePasswordComplexity(val).valid, {
+        error: (iss) =>
+          validatePasswordComplexity(iss.input as string).errors[0] || "Invalid password",
+      }),
     password_confirm: z.string().max(100, "Password too long (max 100 characters)"),
   })
   .refine((data) => data.password_confirm === data.password, {
@@ -34,10 +34,10 @@ export const updateSchema = z
       .string()
       .max(100, "Password too long (max 100 characters)")
       .optional()
-      .refine(
-        (val) => !val || validatePasswordComplexity(val).valid,
-        (val) => ({ message: val ? validatePasswordComplexity(val).errors[0] : undefined })
-      ),
+      .refine((val) => !val || validatePasswordComplexity(val).valid, {
+        error: (iss) =>
+          iss.input ? validatePasswordComplexity(iss.input as string).errors[0] : undefined,
+      }),
     password_confirm: z.string().max(100, "Password too long (max 100 characters)"),
   })
   .refine((data) => data.password_confirm === data.password, {
@@ -55,10 +55,10 @@ export const resetSchema = z
     password: z
       .string()
       .max(100, "Password too long (max 100 characters)")
-      .refine(
-        (val) => validatePasswordComplexity(val).valid,
-        (val) => ({ message: validatePasswordComplexity(val).errors[0] || "Invalid password" })
-      ),
+      .refine((val) => validatePasswordComplexity(val).valid, {
+        error: (iss) =>
+          validatePasswordComplexity(iss.input as string).errors[0] || "Invalid password",
+      }),
     password_confirm: z.string().max(100, "Password too long (max 100 characters)"),
   })
   .refine((data) => data.password_confirm === data.password, {

--- a/src/forms/speciesCreate.ts
+++ b/src/forms/speciesCreate.ts
@@ -9,7 +9,7 @@ export const speciesCreateForm = z.object({
   canonical_species_name: z.string().trim().min(1, "Species name cannot be empty").max(100),
   program_class: z.string().trim().min(1, "Program class cannot be empty").max(100),
   species_type: z.enum(["Fish", "Plant", "Invert", "Coral"], {
-    errorMap: () => ({ message: "Species type must be Fish, Plant, Invert, or Coral" }),
+    error: "Species type must be Fish, Plant, Invert, or Coral",
   }),
   base_points: z
     .string()

--- a/src/forms/utils.ts
+++ b/src/forms/utils.ts
@@ -1,10 +1,10 @@
 import * as z from "zod";
 
 export function validateFormResult<T>(
-  parsed: z.SafeParseReturnType<unknown, T>,
+  parsed: z.ZodSafeParseResult<T>,
   errors: Map<string, string>,
   onError?: () => void
-): parsed is z.SafeParseSuccess<T> {
+): parsed is z.ZodSafeParseSuccess<T> {
   if (parsed.success) {
     return true;
   }
@@ -22,15 +22,14 @@ export function extractValid<T extends z.ZodRawShape>(
   const result: Partial<z.infer<typeof schema>> = {};
 
   for (const key in schema.shape) {
-    const subSchema = schema.shape[key];
+    const subSchema = schema.shape[key] as unknown as z.ZodType;
     const value =
       data && typeof data === "object" && key in data
         ? (data as Record<string, unknown>)[key]
         : undefined;
     const parsed = subSchema.safeParse(value);
     if (parsed.success) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      result[key] = parsed.data;
+      (result as Record<string, unknown>)[key] = parsed.data;
     }
   }
   return result;


### PR DESCRIPTION
Completes the zod 3→4 upgrade that dependabot opened as a version-only bump (#308), which couldn't land on its own because v4 has source-level breaking changes.

## Scope — smaller than it looks
I verified every "breaking" pattern by running zod 4.4.3 directly. The vast majority of usage is **unchanged** in v4: `.min/.email/.regex` string-shorthand messages, `.transform`/`.refine` predicates, `.preprocess`, `z.infer`, `z.coerce`, and `.issues` error handling all still work. Only a handful of error-customization + type APIs actually changed:

| Change | Files |
|---|---|
| `required_error`/`invalid_type_error` → unified `error` param | `cares.ts`, `collection.ts` |
| enum `{ errorMap }` → `{ error }` | `speciesCreate.ts` |
| refine's removed 2nd-arg message **function** → `{ error: (iss) => … }` (reads `iss.input`) | `login.ts` (password-complexity refines) |
| `.default()` now takes the **output** type: `.default("false")` → `.default(false)` on a boolean transform | `collection.ts` |
| `SafeParseReturnType`/`SafeParseSuccess` → `ZodSafeParseResult`/`ZodSafeParseSuccess`; loosen dynamic shape iteration | `utils.ts` |

These v4 error-API changes fail **silently** (schema still parses, custom message is dropped), so I grepped exhaustively and `tsc`'s excess-property checks caught the rest.

## Notes
- **No peer-dep drama** — zod 4 already coexisted in the tree via `@modelcontextprotocol/sdk` → `zod-to-json-schema`; the direct bump just dedupes to one v4.
- **`z.coerce.number` "required" messages**: for coerced numbers a *missing* field becomes `NaN` before the required-check, so the type message shows — this is **identical to v3** (where `required_error` was already inert for coerced numbers), not a regression.

## Verification
- `tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — passes (except the usual live-API `gbif`/`wikipedia` suites, skipped in CI)
- Runtime check confirming custom validation messages still render through the migrated schemas

Supersedes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)