### PR TITLE
fix(test): de-flake species-merge-duplicates via per-test isolation

### DIFF
--- a/src/__tests__/species-merge-duplicates.test.ts
+++ b/src/__tests__/species-merge-duplicates.test.ts
@@ -2,7 +2,7 @@
  * Tests for species merge function with duplicate synonym handling
  */
 
-import { describe, it, before, after } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
 import { open, Database } from "sqlite";
 import sqlite3 from "sqlite3";
@@ -12,8 +12,8 @@ import { mergeSpecies } from "../db/species";
 void describe("Species merge with duplicate synonyms", () => {
   let db: Database;
 
-  void before(async () => {
-    // Create in-memory database for testing
+  void beforeEach(async () => {
+    // Fresh in-memory database per test for isolation
     db = await open({
       filename: ":memory:",
       driver: sqlite3.Database,
@@ -59,7 +59,7 @@ void describe("Species merge with duplicate synonyms", () => {
     overrideConnection(db);
   });
 
-  void after(async () => {
+  void afterEach(async () => {
     await db.close();
   });
 
@@ -127,9 +127,7 @@ void describe("Species merge with duplicate synonyms", () => {
     );
   });
 
-  // TODO: This test is failing due to test isolation issues - the merge function
-  // may not be properly deleting the defunct group. Investigate and fix.
-  void it.skip("should merge species with all unique synonyms", async () => {
+  void it("should merge species with all unique synonyms", async () => {
     // Setup: Create two species with no overlapping names
     await db.run(
       "INSERT INTO species_name_group (group_id, program_class, canonical_genus, canonical_species_name, species_type) VALUES (?, ?, ?, ?, ?)",


### PR DESCRIPTION
## Problem
`src/__tests__/species-merge-duplicates.test.ts` flaked in CI (the "case differences" subtest, an intermittent `AssertionError`). Root cause: the block created **one** shared `:memory:` DB in `before` (runs once) with no per-test reset, so assertions on *global* state — `submissions.length === 1` and `WHERE s.id = 1` — only held depending on test ordering/accumulated rows.

## Fix
`before`/`after` → `beforeEach`/`afterEach`, giving each test a pristine in-memory DB. No production code touched (`mergeSpecies` was fine).

Bonus: this is the same root cause behind the `it.skip("…all unique synonyms")` test (its TODO guessed a merge bug; it was really isolation), so it's **re-enabled** and passes.

## Verification
- Ran the file 5× under node 20 (CI runtime): **2 pass / 0 fail** every time
- `tsc --noEmit` + `npm run lint` clean

Follow-up to the flake observed during the zod 4 migration (#336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)