### PR TITLE
feat: robust email error handling with retry/backoff (closes #47)

### DIFF
--- a/src/__tests__/emailService.test.ts
+++ b/src/__tests__/emailService.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { sendEmailWithRetry } from "../services/emailService";
+
+// Instant sleep so exponential backoff doesn't add real wall-clock to the suite.
+const noSleep = (): Promise<void> => Promise.resolve();
+
+void describe("sendEmailWithRetry", () => {
+  void it("returns true and sends once on first-attempt success", async () => {
+    let calls = 0;
+    const ok = await sendEmailWithRetry(
+      () => {
+        calls++;
+        return Promise.resolve();
+      },
+      { type: "test" },
+      noSleep
+    );
+    assert.strictEqual(ok, true);
+    assert.strictEqual(calls, 1);
+  });
+
+  void it("retries transient failures and succeeds", async () => {
+    let calls = 0;
+    const send = (): Promise<void> => {
+      calls++;
+      return calls < 3 ? Promise.reject(new Error(`transient ${calls}`)) : Promise.resolve();
+    };
+    const ok = await sendEmailWithRetry(send, { type: "test", maxRetries: 3 }, noSleep);
+    assert.strictEqual(ok, true);
+    assert.strictEqual(calls, 3);
+  });
+
+  void it("waits with exponential backoff between attempts", async () => {
+    const delays: number[] = [];
+    const sleep = (ms: number): Promise<void> => {
+      delays.push(ms);
+      return Promise.resolve();
+    };
+    const send = (): Promise<void> => Promise.reject(new Error("always"));
+    await sendEmailWithRetry(send, { type: "test", maxRetries: 3, baseDelayMs: 1000 }, sleep);
+    // 3 attempts → 2 backoff sleeps: 1000 * 2^0, 1000 * 2^1
+    assert.deepStrictEqual(delays, [1000, 2000]);
+  });
+
+  void it("non-critical: returns false after exhausting retries (does not throw)", async () => {
+    let calls = 0;
+    const send = (): Promise<void> => {
+      calls++;
+      return Promise.reject(new Error("nope"));
+    };
+    const result = await sendEmailWithRetry(send, { type: "test", maxRetries: 3 }, noSleep);
+    assert.strictEqual(result, false);
+    assert.strictEqual(calls, 3);
+  });
+
+  void it("critical: rethrows the last error after exhausting retries", async () => {
+    const send = (): Promise<void> => Promise.reject(new Error("boom"));
+    await assert.rejects(
+      () => sendEmailWithRetry(send, { type: "test", critical: true, maxRetries: 2 }, noSleep),
+      /boom/
+    );
+  });
+
+  void it("treats a hung send as a timeout and retries", async () => {
+    let calls = 0;
+    const send = (): Promise<void> => {
+      calls++;
+      return new Promise<void>(() => {
+        /* never resolves */
+      });
+    };
+    const result = await sendEmailWithRetry(
+      send,
+      { type: "test", maxRetries: 2, timeoutMs: 20 },
+      noSleep
+    );
+    assert.strictEqual(result, false);
+    assert.strictEqual(calls, 2);
+  });
+});

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -4,6 +4,7 @@ import { type Submission } from "./db/submissions";
 import { getAdminEmails, MemberRecord } from "./db/members";
 import * as pug from "pug";
 import { logger } from "@/utils/logger";
+import { sendEmailWithRetry } from "./services/emailService";
 
 const DEBUG_EMAIL = process.env.DEBUG_EMAIL;
 const fromEmail = `BASNY Breeder Awards ${config.email.fromEmail}`;
@@ -32,18 +33,22 @@ export async function onSubmissionSend(sub: Submission, member: MemberRecord) {
 
   const admins = await getAdminEmails();
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: member.contact_email,
-    cc: admins,
-    bcc: DEBUG_EMAIL,
-    subject: `Submission Confirmation - ${sub.species_common_name}`,
-    html: renderOnSubmission({
-      domain: config.server.domain,
-      submission: sub,
-      member,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        cc: admins,
+        bcc: DEBUG_EMAIL,
+        subject: `Submission Confirmation - ${sub.species_common_name}`,
+        html: renderOnSubmission({
+          domain: config.server.domain,
+          submission: sub,
+          member,
+        }),
+      }),
+    { type: "submission_created", context: { submissionId: sub.id, recipient: member.contact_email } }
+  );
 }
 
 export async function sendChangesRequest(sub: Submission, contact_email: string, content: string) {
@@ -54,14 +59,18 @@ export async function sendChangesRequest(sub: Submission, contact_email: string,
 
   const admins = await getAdminEmails();
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: contact_email,
-    cc: admins,
-    bcc: DEBUG_EMAIL,
-    subject: `Changes Requested - ${sub.species_common_name}`,
-    text: content,
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: contact_email,
+        cc: admins,
+        bcc: DEBUG_EMAIL,
+        subject: `Changes Requested - ${sub.species_common_name}`,
+        text: content,
+      }),
+    { type: "changes_request", context: { submissionId: sub.id, recipient: contact_email } }
+  );
 }
 
 const renderOnChangesRequested = pug.compileFile("src/views/email/onChangesRequested.pug");
@@ -77,20 +86,24 @@ export async function onChangesRequested(
 
   const admins = await getAdminEmails();
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: member.contact_email,
-    cc: admins,
-    bcc: DEBUG_EMAIL,
-    subject: `Changes Requested - ${submission.species_common_name}`,
-    html: renderOnChangesRequested({
-      domain: config.server.domain,
-      submission,
-      member,
-      reason,
-      programContactEmail: config.email.adminsEmail,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        cc: admins,
+        bcc: DEBUG_EMAIL,
+        subject: `Changes Requested - ${submission.species_common_name}`,
+        html: renderOnChangesRequested({
+          domain: config.server.domain,
+          submission,
+          member,
+          reason,
+          programContactEmail: config.email.adminsEmail,
+        }),
+      }),
+    { type: "changes_requested", context: { submissionId: submission.id, recipient: member.contact_email } }
+  );
 }
 
 const renderOnApprove = pug.compileFile("src/views/email/onApproval.pug");
@@ -100,17 +113,21 @@ export async function onSubmissionApprove(sub: Submission, member: MemberRecord)
     return;
   }
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: member.contact_email,
-    bcc: DEBUG_EMAIL,
-    subject: `Submission Approved! - ${sub.species_common_name}`,
-    html: renderOnApprove({
-      domain: config.server.domain,
-      submission: sub,
-      member,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        bcc: DEBUG_EMAIL,
+        subject: `Submission Approved! - ${sub.species_common_name}`,
+        html: renderOnApprove({
+          domain: config.server.domain,
+          submission: sub,
+          member,
+        }),
+      }),
+    { type: "submission_approved", context: { submissionId: sub.id, recipient: member.contact_email } }
+  );
 }
 
 const renderResetEmail = pug.compileFile("src/views/email/onForgotPassword.pug");
@@ -120,17 +137,22 @@ export async function sendResetEmail(email: string, display_name: string, code: 
     return;
   }
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: email,
-    subject: "Reset Password",
-    html: renderResetEmail({
-      domain: config.server.domain,
-      display_name,
-      code,
-      programContactEmail: config.email.adminsEmail,
-    }),
-  });
+  // Critical: the reset flow can't proceed without this email, so rethrow on failure.
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: email,
+        subject: "Reset Password",
+        html: renderResetEmail({
+          domain: config.server.domain,
+          display_name,
+          code,
+          programContactEmail: config.email.adminsEmail,
+        }),
+      }),
+    { type: "password_reset", critical: true, context: { recipient: email } }
+  );
 }
 
 const renderInviteEmail = pug.compileFile("src/views/email/invite.pug");
@@ -146,19 +168,23 @@ export async function sendInviteEmail(
     return;
   }
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: email,
-    bcc: DEBUG_EMAIL,
-    subject: "Welcome to the BASNY Breeders Awards Program!",
-    html: renderInviteEmail({
-      domain: config.server.domain,
-      display_name,
-      code,
-      member,
-      submissions,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: email,
+        bcc: DEBUG_EMAIL,
+        subject: "Welcome to the BASNY Breeders Awards Program!",
+        html: renderInviteEmail({
+          domain: config.server.domain,
+          display_name,
+          code,
+          member,
+          submissions,
+        }),
+      }),
+    { type: "member_invite", context: { recipient: email } }
+  );
 }
 
 const renderLevelUpgrade = pug.compileFile("src/views/email/onLevelUpgrade.pug");
@@ -181,19 +207,23 @@ export async function onLevelUpgrade(
     coral: "Coral Awards Program (CAP)",
   };
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: member.contact_email,
-    bcc: DEBUG_EMAIL,
-    subject: `Congratulations! New ${programNames[program]} Level: ${newLevel}`,
-    html: renderLevelUpgrade({
-      domain: config.server.domain,
-      member,
-      program,
-      newLevel,
-      totalPoints,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        bcc: DEBUG_EMAIL,
+        subject: `Congratulations! New ${programNames[program]} Level: ${newLevel}`,
+        html: renderLevelUpgrade({
+          domain: config.server.domain,
+          member,
+          program,
+          newLevel,
+          totalPoints,
+        }),
+      }),
+    { type: "level_upgrade", context: { memberId: member.id, newLevel, recipient: member.contact_email } }
+  );
 }
 
 export async function onScreeningApproved(
@@ -206,18 +236,22 @@ export async function onScreeningApproved(
     return;
   }
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: member.contact_email,
-    bcc: DEBUG_EMAIL,
-    subject: `Screening Approved - ${submission.species_common_name}`,
-    html: renderOnScreeningApproved({
-      domain: config.server.domain,
-      submission,
-      member,
-      witness,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        bcc: DEBUG_EMAIL,
+        subject: `Screening Approved - ${submission.species_common_name}`,
+        html: renderOnScreeningApproved({
+          domain: config.server.domain,
+          submission,
+          member,
+          witness,
+        }),
+      }),
+    { type: "screening_approved", context: { submissionId: submission.id, recipient: member.contact_email } }
+  );
 }
 
 export async function onScreeningRejected(
@@ -230,17 +264,21 @@ export async function onScreeningRejected(
     return;
   }
 
-  return transporter.sendMail({
-    from: fromEmail,
-    to: member.contact_email,
-    bcc: DEBUG_EMAIL,
-    subject: `Additional Information Needed - ${submission.species_common_name}`,
-    html: renderOnScreeningRejected({
-      domain: config.server.domain,
-      submission,
-      member,
-      reason,
-      programContactEmail: config.email.adminsEmail,
-    }),
-  });
+  await sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        bcc: DEBUG_EMAIL,
+        subject: `Additional Information Needed - ${submission.species_common_name}`,
+        html: renderOnScreeningRejected({
+          domain: config.server.domain,
+          submission,
+          member,
+          reason,
+          programContactEmail: config.email.adminsEmail,
+        }),
+      }),
+    { type: "screening_rejected", context: { submissionId: submission.id, recipient: member.contact_email } }
+  );
 }

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,0 +1,103 @@
+import { logger } from "@/utils/logger";
+
+/**
+ * Centralized send wrapper for outbound email: retry with exponential backoff,
+ * a per-attempt timeout, and structured logging.
+ *
+ * Two modes via `critical`:
+ *  - non-critical (default): on final failure, log and return `false` so the
+ *    calling business operation (submission, approval, etc.) still succeeds.
+ *  - critical (`critical: true`): on final failure, rethrow so the caller can
+ *    surface the error (e.g. password reset can't proceed without the email).
+ */
+
+export interface SendEmailOptions {
+  /** Short machine label for logs, e.g. "submission_created". */
+  type: string;
+  /** Extra structured context for logs (recipient, ids, …). */
+  context?: Record<string, unknown>;
+  /** Rethrow on final failure instead of swallowing. Default false. */
+  critical?: boolean;
+  /** Total attempts (including the first). Default 3. */
+  maxRetries?: number;
+  /** Base backoff in ms; delays are base * 2^(attempt-1). Default 1000. */
+  baseDelayMs?: number;
+  /** Per-attempt timeout in ms. Default 30000. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+const errMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Reject if `promise` doesn't settle within `ms` (does not cancel the work). */
+async function withTimeout<T>(promise: Promise<T>, ms: number, type: string): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Email '${type}' timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+/**
+ * Run `send` with retry/backoff/timeout. Returns true on success. On final
+ * failure: returns false (non-critical) or throws (critical).
+ *
+ * `sleep` is injectable for tests so backoff doesn't add real wall-clock.
+ */
+export async function sendEmailWithRetry(
+  send: () => Promise<unknown>,
+  options: SendEmailOptions,
+  sleep: (ms: number) => Promise<void> = defaultSleep
+): Promise<boolean> {
+  const { type, context, critical = false } = options;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await withTimeout(Promise.resolve(send()), timeoutMs, type);
+      if (attempt > 1) {
+        logger.info("Email sent after retry", { type, attempt, ...context });
+      }
+      return true;
+    } catch (err) {
+      lastError = err;
+      logger.warn(`Email attempt ${attempt}/${maxRetries} failed`, {
+        type,
+        attempt,
+        error: errMessage(err),
+        ...context,
+      });
+      if (attempt < maxRetries) {
+        await sleep(baseDelayMs * 2 ** (attempt - 1));
+      }
+    }
+  }
+
+  logger.error("Email failed after retries", {
+    type,
+    attempts: maxRetries,
+    lastError: errMessage(lastError),
+    ...context,
+  });
+
+  if (critical) {
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`Email '${type}' failed after ${maxRetries} attempts: ${errMessage(lastError)}`);
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #47.

## Problem
All ~10 notification emails in `src/notifications.ts` called `transporter.sendMail()` directly with no retry, timeout, or error handling. A transient SMTP hiccup could throw straight out of a core operation — creating a submission, approving one, a level upgrade, or a member invite could fail entirely because the *email* failed.

## Approach
New `src/services/emailService.ts` → `sendEmailWithRetry()`:
- Retry with **exponential backoff** (3 attempts, 1s/2s) and a **30s per-attempt timeout**
- **Structured logging**: `warn` per failed attempt, `error` on final failure, with a `type` label + context (recipient, ids) for correlation
- **Two modes**:
  - *non-critical* (default) — log and return `false` on final failure so the business operation still succeeds
  - *critical* — rethrow. **Password reset** is the only critical send (the flow genuinely can't proceed without the email); everything else is non-critical

Every send in `notifications.ts` now routes through the wrapper. No call sites changed (none used the return value), so the only behavior change is the intended one: non-critical email failures no longer break core flows.

## Tests
`src/__tests__/emailService.test.ts` — success, retry-then-succeed, exponential-backoff delays, non-critical-returns-false, critical-rethrows, and hung-send timeout. `sleep` is injected so backoff adds no real wall-clock.

## Verification
`tsc`, `npm run lint`, full suite **989/0** (all under node 22).

## Note
Implemented Phases 1–3 of the issue (wrapper + wire-up + the high-risk call sites are now protected by the non-critical default). Skipped Phase 4's `config.json` knobs — retry params are sensible code constants; can be made configurable later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)