### PR TITLE
feat: email reminder when waiting period ends (closes #324)

### DIFF
--- a/db/migrations/054-add-final-submission-reminder.sql
+++ b/db/migrations/054-add-final-submission-reminder.sql
@@ -1,0 +1,9 @@
+-- Track when the "waiting period complete — ready for final submission" reminder
+-- was emailed to the submitter, so the daily reminder job sends it at most once
+-- per submission. NULL = not yet reminded.
+--
+-- Companion to migration 053 (final_submission_on): after the waiting period
+-- elapses a submission sits in the awaiting-final-submission state until the
+-- submitter acts, and this column gates the nudge email that prompts them.
+
+ALTER TABLE submissions ADD COLUMN final_submission_reminder_sent_on DATETIME;

--- a/src/__tests__/finalSubmissionReminder.test.ts
+++ b/src/__tests__/finalSubmissionReminder.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { runFinalSubmissionReminders } from "@/scheduled/finalSubmissionReminder";
+import { getSubmissionById, setFinalSubmission } from "../db/submissions";
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+  createTestSubmission,
+  type TestContext,
+} from "./helpers/testHelpers";
+
+/**
+ * Tests for the daily final-submission reminder job. Emails are disabled under
+ * NODE_ENV=test, so onWaitingPeriodComplete is a no-op success — this exercises
+ * the selection query and the idempotent "mark reminded" bookkeeping.
+ */
+
+const SIXTY_FIVE_DAYS_AGO = new Date(Date.now() - 65 * 24 * 60 * 60 * 1000).toISOString();
+const TEN_DAYS_AGO = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+const reminded = async (id: number): Promise<boolean> => {
+  const sub = await getSubmissionById(id);
+  return Boolean(sub?.final_submission_reminder_sent_on);
+};
+
+void describe("Final-submission reminder job", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDatabase({ adminCount: 1 });
+  });
+
+  afterEach(async () => {
+    await teardownTestDatabase(ctx);
+  });
+
+  void test("reminds a confirmed, past-waiting-period submission once", async () => {
+    const id = await createTestSubmission(ctx.db, {
+      memberId: ctx.member.id,
+      submitted: true,
+      witnessStatus: "confirmed",
+      witnessedBy: ctx.admin.id,
+      reproductionDate: SIXTY_FIVE_DAYS_AGO,
+    });
+
+    const result = await runFinalSubmissionReminders();
+
+    assert.strictEqual(result.sent, 1);
+    assert.strictEqual(result.failed, 0);
+    assert.strictEqual(await reminded(id), true);
+  });
+
+  void test("does not remind a submission still in its waiting period", async () => {
+    const id = await createTestSubmission(ctx.db, {
+      memberId: ctx.member.id,
+      submitted: true,
+      witnessStatus: "confirmed",
+      witnessedBy: ctx.admin.id,
+      reproductionDate: TEN_DAYS_AGO,
+    });
+
+    const result = await runFinalSubmissionReminders();
+
+    assert.strictEqual(result.sent, 0);
+    assert.strictEqual(await reminded(id), false);
+  });
+
+  void test("does not remind an unconfirmed submission", async () => {
+    const id = await createTestSubmission(ctx.db, {
+      memberId: ctx.member.id,
+      submitted: true,
+      witnessStatus: "pending",
+      reproductionDate: SIXTY_FIVE_DAYS_AGO,
+    });
+
+    await runFinalSubmissionReminders();
+
+    assert.strictEqual(await reminded(id), false);
+  });
+
+  void test("does not remind a submission already marked final-submitted", async () => {
+    const id = await createTestSubmission(ctx.db, {
+      memberId: ctx.member.id,
+      submitted: true,
+      witnessStatus: "confirmed",
+      witnessedBy: ctx.admin.id,
+      reproductionDate: SIXTY_FIVE_DAYS_AGO,
+    });
+    await setFinalSubmission(id, ctx.member.id, false);
+
+    const result = await runFinalSubmissionReminders();
+
+    assert.strictEqual(result.sent, 0);
+    assert.strictEqual(await reminded(id), false);
+  });
+
+  void test("is idempotent: a second run does not re-remind", async () => {
+    await createTestSubmission(ctx.db, {
+      memberId: ctx.member.id,
+      submitted: true,
+      witnessStatus: "confirmed",
+      witnessedBy: ctx.admin.id,
+      reproductionDate: SIXTY_FIVE_DAYS_AGO,
+    });
+
+    const first = await runFinalSubmissionReminders();
+    const second = await runFinalSubmissionReminders();
+
+    assert.strictEqual(first.sent, 1);
+    assert.strictEqual(second.sent, 0);
+  });
+});

--- a/src/db/submissions.ts
+++ b/src/db/submissions.ts
@@ -97,6 +97,7 @@ export type Submission = {
   changes_requested_reason: string | null;
 
   final_submission_on: string | null;
+  final_submission_reminder_sent_on: string | null;
 
   is_cares_species?: number | null;
 };
@@ -578,6 +579,51 @@ export async function clearFinalSubmission(
 
     logger.info("Submission removed from approval queue", { submissionId, userId, isAdmin });
   });
+}
+
+export interface FinalReminderCandidate extends Submission {
+  contact_email: string;
+  member_name: string;
+}
+
+/**
+ * Submissions ready for the "waiting period complete" reminder: witnessed and
+ * confirmed, past their waiting period, not yet final-submitted, not approved
+ * or denied, and not already reminded. Joined with the member's contact info.
+ *
+ * The waiting-period length depends on species, so the SQL filters the simple
+ * boolean conditions and the per-species elapsed check is applied in JS via the
+ * shared `isEligibleForApproval` helper.
+ */
+export async function getSubmissionsAwaitingFinalReminder(): Promise<FinalReminderCandidate[]> {
+  const candidates = await query<FinalReminderCandidate>(
+    `SELECT submissions.*, members.contact_email, members.display_name AS member_name
+       FROM submissions
+       LEFT JOIN members ON submissions.member_id = members.id
+      WHERE submissions.submitted_on IS NOT NULL
+        AND submissions.approved_on IS NULL
+        AND submissions.denied_on IS NULL
+        AND submissions.witness_verification_status = 'confirmed'
+        AND submissions.final_submission_on IS NULL
+        AND submissions.final_submission_reminder_sent_on IS NULL`
+  );
+  return candidates.filter((submission) => isEligibleForApproval(submission));
+}
+
+/**
+ * Idempotently record that the final-submission reminder has been emailed.
+ * The `IS NULL` guard makes a concurrent/duplicate send a no-op.
+ */
+export async function markFinalSubmissionReminderSent(submissionId: number): Promise<void> {
+  const stmt = await writeConn.prepare(
+    `UPDATE submissions SET final_submission_reminder_sent_on = ?
+      WHERE id = ? AND final_submission_reminder_sent_on IS NULL`
+  );
+  try {
+    await stmt.run(new Date().toISOString(), submissionId);
+  } finally {
+    await stmt.finalize();
+  }
 }
 
 export async function confirmWitness(submissionId: number, witnessAdminId: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import * as cardDemo from "./routes/cardDemo";
 import * as hoverCardDemo from "./routes/hoverCardDemo";
 import testRouter from "./routes/test";
 import { startScheduledCleanup } from "./scheduled/cleanup";
+import { startFinalSubmissionReminders } from "./scheduled/finalSubmissionReminder";
 import { startMcpHttpServer } from "./mcp/http-server";
 import { logger } from "./utils/logger";
 
@@ -412,9 +413,10 @@ async function main() {
 
     if (process.env.NODE_ENV === "production") {
       startScheduledCleanup();
-      logger.info("Scheduled cleanup enabled (production mode)");
+      startFinalSubmissionReminders();
+      logger.info("Scheduled tasks enabled (production mode)");
     } else {
-      logger.info("Scheduled cleanup disabled (non-production environment)");
+      logger.info("Scheduled tasks disabled (non-production environment)");
     }
 
     void startMcpHttpServer().catch((error) => {

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -130,6 +130,44 @@ export async function onSubmissionApprove(sub: Submission, member: MemberRecord)
   );
 }
 
+const renderWaitingPeriodComplete = pug.compileFile("src/views/email/onWaitingPeriodComplete.pug");
+/**
+ * Nudge sent when a submission's waiting period elapses, prompting the submitter
+ * to bring the fish/plant/coral to the next meeting and click "Brought to
+ * Meeting" so it enters the approval queue. Non-critical (the daily job logs and
+ * continues on failure; it will not be marked reminded, so it retries next run).
+ */
+export async function onWaitingPeriodComplete(
+  sub: Submission,
+  member: Pick<MemberRecord, "contact_email" | "display_name">
+): Promise<boolean> {
+  if (EMAILS_DISABLED) {
+    logger.info("Email disabled - would have sent waiting period complete reminder", {
+      submissionId: sub.id,
+    });
+    return true;
+  }
+
+  return sendEmailWithRetry(
+    () =>
+      transporter.sendMail({
+        from: fromEmail,
+        to: member.contact_email,
+        bcc: DEBUG_EMAIL,
+        subject: `Ready for the next meeting - ${sub.species_common_name}`,
+        html: renderWaitingPeriodComplete({
+          domain: config.server.domain,
+          submission: sub,
+          member,
+        }),
+      }),
+    {
+      type: "waiting_period_complete",
+      context: { submissionId: sub.id, recipient: member.contact_email },
+    }
+  );
+}
+
 const renderResetEmail = pug.compileFile("src/views/email/onForgotPassword.pug");
 export async function sendResetEmail(email: string, display_name: string, code: string) {
   if (EMAILS_DISABLED) {

--- a/src/scheduled/finalSubmissionReminder.ts
+++ b/src/scheduled/finalSubmissionReminder.ts
@@ -1,0 +1,104 @@
+import { ready } from "@/db/conn";
+import { logger } from "@/utils/logger";
+import {
+  getSubmissionsAwaitingFinalReminder,
+  markFinalSubmissionReminderSent,
+} from "@/db/submissions";
+import { onWaitingPeriodComplete } from "@/notifications";
+
+/**
+ * Find submissions whose waiting period has elapsed and that are sitting in the
+ * awaiting-final-submission state, email each submitter a one-time nudge to
+ * bring their entry to the next meeting, and record that the reminder was sent.
+ *
+ * Idempotent: only emails submissions not yet reminded, and marks each as
+ * reminded only after a successful send — so a transient email failure is
+ * retried on the next run rather than silently dropped.
+ */
+export async function runFinalSubmissionReminders(): Promise<{ sent: number; failed: number }> {
+  let sent = 0;
+  let failed = 0;
+
+  try {
+    await ready;
+
+    const candidates = await getSubmissionsAwaitingFinalReminder();
+    if (candidates.length === 0) {
+      logger.info("No submissions awaiting final-submission reminder");
+      return { sent, failed };
+    }
+
+    logger.info(`Sending final-submission reminders to ${candidates.length} submitter(s)`);
+
+    for (const submission of candidates) {
+      if (!submission.contact_email) {
+        logger.warn("Skipping final-submission reminder: submitter has no contact email", {
+          submissionId: submission.id,
+        });
+        continue;
+      }
+
+      const delivered = await onWaitingPeriodComplete(submission, {
+        contact_email: submission.contact_email,
+        display_name: submission.member_name,
+      });
+
+      if (delivered) {
+        await markFinalSubmissionReminderSent(submission.id);
+        sent++;
+      } else {
+        failed++;
+        logger.warn("Final-submission reminder not sent; will retry next run", {
+          submissionId: submission.id,
+        });
+      }
+    }
+
+    logger.info(`Final-submission reminders complete: sent=${sent}, failed=${failed}`);
+  } catch (err) {
+    logger.error("Error sending final-submission reminders", err);
+  }
+
+  return { sent, failed };
+}
+
+let reminderInterval: NodeJS.Timeout | null = null;
+
+/**
+ * Start the daily final-submission reminder task.
+ * Runs immediately on startup (to catch any missed days while the machine was
+ * stopped — Fly scales to zero) and then daily at 4:00 AM server time.
+ */
+export function startFinalSubmissionReminders(): void {
+  // Run on startup to catch up on anything missed while the machine was stopped.
+  void runFinalSubmissionReminders();
+
+  const now = new Date();
+  const next4AM = new Date();
+  next4AM.setHours(4, 0, 0, 0);
+  if (now.getHours() >= 4) {
+    next4AM.setDate(next4AM.getDate() + 1);
+  }
+  const msUntilNext4AM = next4AM.getTime() - now.getTime();
+
+  logger.info(`Next final-submission reminder run scheduled for ${next4AM.toISOString()}`);
+
+  setTimeout(() => {
+    void runFinalSubmissionReminders();
+    reminderInterval = setInterval(
+      () => {
+        void runFinalSubmissionReminders();
+      },
+      24 * 60 * 60 * 1000
+    );
+  }, msUntilNext4AM);
+}
+
+/** Stop the scheduled reminder task (graceful shutdown / tests). */
+export function stopFinalSubmissionReminders(): void {
+  if (reminderInterval) {
+    clearInterval(reminderInterval);
+    reminderInterval = null;
+    logger.info("Scheduled final-submission reminders stopped");
+  }
+}

--- a/src/views/email/onWaitingPeriodComplete.pug
+++ b/src/views/email/onWaitingPeriodComplete.pug
@@ -1,0 +1,75 @@
+doctype html
+html
+	head
+		meta(charset="utf-8")
+		title Ready for the Next Meeting
+		style.
+			body {
+				font-family: Arial, sans-serif;
+				line-height: 1.6;
+				color: #333;
+				max-width: 600px;
+				margin: 0 auto;
+				padding: 20px;
+			}
+			.header {
+				background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+				color: white;
+				padding: 30px 20px;
+				text-align: center;
+				border-radius: 8px 8px 0 0;
+			}
+			.content {
+				background-color: #f8fafc;
+				padding: 20px;
+				border: 1px solid #e2e8f0;
+			}
+			.submission-details {
+				background-color: white;
+				padding: 15px;
+				border-radius: 6px;
+				margin: 15px 0;
+				border-left: 4px solid #3b82f6;
+			}
+			.button {
+				display: inline-block;
+				background: #2563eb;
+				color: white;
+				padding: 12px 24px;
+				border-radius: 6px;
+				margin: 15px 0;
+			}
+			.footer {
+				background-color: #1e293b;
+				color: white;
+				padding: 20px;
+				text-align: center;
+				border-radius: 0 0 8px 8px;
+				font-size: 14px;
+			}
+	body
+		.header
+			h1 Your waiting period is complete!
+		.content
+			p Hi #{member.display_name},
+			p
+				| The waiting period for your submission has elapsed — it's ready for the
+				| next step.
+			.submission-details
+				strong Species:
+				|  #{submission.species_common_name}
+			p
+				| Bring the fish, plant, or coral to the next monthly meeting, then open
+				| your submission and click
+				strong  “Brought to Meeting”
+				|  to enter the approval queue. Submissions wait here until you confirm,
+				| so this step is up to you.
+			p(style="text-align: center;")
+				a.button(href=`https://${domain}/submissions/${submission.id}` style="color: white; text-decoration: none;") View Your Submission
+			p
+				| If you've already brought it to a meeting and queued it, you can ignore
+				| this reminder.
+		.footer
+			p BASNY Breeder Awards Program
+			p
+				a(href="https://basny.org" style="color: white;") basny.org


### PR DESCRIPTION
Closes #324. Completes the manual final-submission flow shipped in #323.

## Why
After a submission's waiting period elapses it no longer auto-promotes — it sits in the `awaiting-final-submission` state until the submitter clicks "Brought to Meeting." Without a nudge, witnessed-but-not-queued submissions pile up forgotten. This adds a daily job that emails the submitter **once** when their entry becomes ready.

## What
- **Migration 054** — `final_submission_reminder_sent_on` column (one-time idempotency flag, mirrors the `final_submission_on` pattern).
- **`getSubmissionsAwaitingFinalReminder()`** — selects submissions that are confirmed, past their waiting period, not yet final-submitted/approved/denied, and not yet reminded. The per-species waiting length (30d marine / 60d otherwise) is applied via the shared `isEligibleForApproval` helper. **`markFinalSubmissionReminderSent()`** has an `IS NULL` guard.
- **`onWaitingPeriodComplete()`** — uses the robust send wrapper from #47 (non-critical) and returns success, so the job marks a submission reminded **only after a real send** — a transient email failure is retried next run, not silently dropped.
- **`onWaitingPeriodComplete.pug`** — email template (species, submission link, "Brought to Meeting" explanation).
- **`scheduled/finalSubmissionReminder.ts`** — modeled on `scheduled/cleanup.ts`: runs on boot (catches days missed while the Fly machine was scaled to zero) + daily at 4 AM, wired into `index.ts` next to `startScheduledCleanup`.

## Tests
`finalSubmissionReminder.test.ts` — eligible → reminded once; in-waiting-period → not; unconfirmed → not; already-final-submitted → not; idempotent (second run sends 0). Plus a manual render check of the template with sample data.

## Verification
`tsc`, lint, full suite **996/0** (node 22). Template renders with all expected content.

## Note
Reuses the existing in-process scheduler pattern (`cleanup.ts`) per the issue's spec — no new Fly infra. The boot-run + idempotent design tolerates the scale-to-zero machine missing an exact 4 AM tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)