### PR TITLE
feat: admin-triggered external species data sync (part of #249)

### DIFF
--- a/src/__tests__/externalDataSync.test.ts
+++ b/src/__tests__/externalDataSync.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import type { Database } from "sqlite";
+import { runExternalDataSync, type EnrichmentClients } from "@/services/externalDataSync";
+import {
+  getSpeciesExternalReferences,
+  getSpeciesImages,
+  setSpeciesExternalReferences,
+} from "@/db/species";
+import { getAllSyncLog } from "@/db/external-data-sync";
+import { setupTestDatabase, teardownTestDatabase, type TestContext } from "./helpers/testHelpers";
+
+const insertSpecies = (db: Database, groupId: number, genus: string, species: string) =>
+  db.run(
+    `INSERT INTO species_name_group
+       (group_id, program_class, canonical_genus, canonical_species_name, species_type)
+     VALUES (?, 'Cyprinids', ?, ?, 'Fish')`,
+    [groupId, genus, species]
+  );
+
+// Fake clients: respond per-genus so we can model success / not-found / error.
+const clients: EnrichmentClients = {
+  wikipedia: {
+    getExternalData: (genus: string) => {
+      if (genus === "Boom") return Promise.reject(new Error("wiki upstream 500"));
+      if (genus === "Danio") {
+        return Promise.resolve({
+          wikidataUrl: "https://www.wikidata.org/wiki/Q1",
+          wikipediaUrls: { en: "https://en.wikipedia.org/wiki/Danio_rerio" },
+          imageUrls: ["https://upload.wikimedia.org/danio.jpg"],
+        });
+      }
+      return Promise.resolve(null); // not found
+    },
+  },
+  gbif: {
+    getExternalData: () =>
+      Promise.resolve({
+        gbifUrl: "https://www.gbif.org/species/123",
+        occurrenceMapUrl: "https://api.gbif.org/v2/map/123.png",
+        imageUrls: ["https://api.gbif.org/img.jpg"],
+      }),
+  },
+};
+
+void describe("externalDataSync.runExternalDataSync", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await setupTestDatabase({ adminCount: 1 });
+    // Migrations seed the species catalog; start from a clean slate so the sync
+    // only sees our fixtures and the log counts are deterministic.
+    await ctx.db.exec(
+      `DELETE FROM species_name_group;
+       DELETE FROM external_data_sync_log;
+       DELETE FROM species_external_references;
+       DELETE FROM species_images;`
+    );
+    await insertSpecies(ctx.db, 100, "Danio", "rerio"); // wiki + gbif hit
+    await insertSpecies(ctx.db, 101, "Poecilia", "reticulata"); // wiki not-found, gbif hit
+    await insertSpecies(ctx.db, 102, "Boom", "boom"); // wiki throws, gbif hit
+  });
+
+  afterEach(async () => {
+    await teardownTestDatabase(ctx);
+  });
+
+  void test("syncs references/images and records per-source log", async () => {
+    const summary = await runExternalDataSync({ limit: 10 }, clients);
+
+    assert.strictEqual(summary.processed, 3);
+    assert.strictEqual(summary.notFound, 1, "Poecilia wikipedia → not found");
+    assert.strictEqual(summary.errors, 1, "Boom wikipedia → error");
+
+    // group 100 got both Wikipedia and GBIF references
+    const refs = (await getSpeciesExternalReferences(100)).map((r) => r.reference_url);
+    assert.ok(refs.includes("https://www.wikidata.org/wiki/Q1"));
+    assert.ok(refs.includes("https://en.wikipedia.org/wiki/Danio_rerio"));
+    assert.ok(refs.includes("https://www.gbif.org/species/123"));
+    assert.ok(refs.includes("https://api.gbif.org/v2/map/123.png"));
+
+    const images = (await getSpeciesImages(100)).map((i) => i.image_url);
+    assert.ok(images.includes("https://upload.wikimedia.org/danio.jpg"));
+    assert.ok(images.includes("https://api.gbif.org/img.jpg"));
+
+    // group 102 still gets GBIF data even though Wikipedia errored
+    const refs102 = (await getSpeciesExternalReferences(102)).map((r) => r.reference_url);
+    assert.ok(refs102.includes("https://www.gbif.org/species/123"));
+
+    // log has an entry per source per species (6 total)
+    const log = await getAllSyncLog(ctx.db);
+    assert.strictEqual(log.length, 6);
+    assert.ok(log.some((e) => e.source === "wikipedia" && e.status === "not_found"));
+    assert.ok(log.some((e) => e.source === "wikipedia" && e.status === "error"));
+  });
+
+  void test("is additive — preserves pre-existing references", async () => {
+    await setSpeciesExternalReferences(100, ["https://example.com/manual"]);
+
+    await runExternalDataSync({ limit: 10 }, clients);
+
+    const refs = (await getSpeciesExternalReferences(100)).map((r) => r.reference_url);
+    assert.ok(refs.includes("https://example.com/manual"), "manual ref preserved");
+    assert.ok(refs.includes("https://www.gbif.org/species/123"), "synced ref added");
+  });
+
+  void test("skips species synced within the staleness window on a second run", async () => {
+    const first = await runExternalDataSync({ limit: 10 }, clients);
+    assert.strictEqual(first.processed, 3);
+
+    // every species had at least one successful source → last_external_sync set
+    const second = await runExternalDataSync({ limit: 10 }, clients);
+    assert.strictEqual(second.processed, 0);
+  });
+
+  void test("respects the limit", async () => {
+    const summary = await runExternalDataSync({ limit: 1 }, clients);
+    assert.strictEqual(summary.processed, 1);
+  });
+});

--- a/src/__tests__/pug-templates.test.ts
+++ b/src/__tests__/pug-templates.test.ts
@@ -489,6 +489,7 @@ void describe("Pug Template Rendering", () => {
       /^mixins\/submissionImages\.pug$/, // Mixin-only template
       /^onSelectType\.pug$/, // Include-only template
       /^member\/caresSection\.pug$/, // Mixin-only template (included by member.pug)
+      /^admin\/externalDataStatus\.pug$/, // Partial included by externalData.pug + served via HTMX
     ];
 
     return !skipPatterns.some((pattern) => pattern.test(relativePath));
@@ -533,6 +534,23 @@ void describe("Pug Template Rendering", () => {
           case "bapForm/form.pug":
           case "submit.pug":
             templateData.formAction = "/submit";
+            break;
+
+          case "admin/externalData.pug":
+            templateData.state = {
+              running: false,
+              startedAt: null,
+              finishedAt: null,
+              lastSummary: { processed: 0, linksAdded: 0, imagesAdded: 0, notFound: 0, errors: 0 },
+              lastError: null,
+            };
+            templateData.stats = {
+              total_species: 0,
+              species_with_external_links: 0,
+              species_with_images: 0,
+              successful_syncs: 0,
+            };
+            templateData.recentLog = [];
             break;
 
           case "species/detail.pug":

--- a/src/routes/admin/externalData.ts
+++ b/src/routes/admin/externalData.ts
@@ -1,0 +1,32 @@
+import { Response } from "express";
+import { MulmRequest } from "@/sessions";
+import { writeConn } from "@/db/conn";
+import { getExternalDataSyncStats, getAllSyncLog } from "@/db/external-data-sync";
+import { startExternalDataSync, getExternalDataSyncState } from "@/services/externalDataSync";
+
+// Bound a manually-triggered run so an admin can watch it finish in a few minutes.
+const MANUAL_SYNC_LIMIT = 25;
+
+async function panelData() {
+  const [stats, recentLog] = await Promise.all([
+    getExternalDataSyncStats(writeConn),
+    getAllSyncLog(writeConn, undefined, undefined, 15),
+  ]);
+  return { state: getExternalDataSyncState(), stats, recentLog };
+}
+
+/** Full page: GET /admin/external-data */
+export const externalDataPage = async (_req: MulmRequest, res: Response) => {
+  res.render("admin/externalData", { title: "External Data Sync", ...(await panelData()) });
+};
+
+/** Status partial for HTMX polling: GET /admin/external-data/status */
+export const externalDataStatus = async (_req: MulmRequest, res: Response) => {
+  res.render("admin/externalDataStatus", await panelData());
+};
+
+/** Fire-and-forget trigger: POST /admin/external-data/sync */
+export const triggerExternalDataSync = async (_req: MulmRequest, res: Response) => {
+  startExternalDataSync({ limit: MANUAL_SYNC_LIMIT });
+  res.render("admin/externalDataStatus", await panelData());
+};

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -2,10 +2,16 @@ import { Router } from "express";
 import { requireAdmin } from "./admin";
 import * as admin from "./admin";
 import * as speciesAdmin from "./admin/species";
+import * as externalData from "./admin/externalData";
 
 const adminRouter = Router();
 
 adminRouter.use(requireAdmin);
+
+// External species data sync (Wikipedia / GBIF)
+adminRouter.get("/external-data", externalData.externalDataPage);
+adminRouter.get("/external-data/status", externalData.externalDataStatus);
+adminRouter.post("/external-data/sync", externalData.triggerExternalDataSync);
 
 // Species management
 adminRouter.get("/species", speciesAdmin.listSpecies);

--- a/src/services/externalDataSync.ts
+++ b/src/services/externalDataSync.ts
@@ -1,0 +1,227 @@
+import { writeConn } from "@/db/conn";
+import { logger } from "@/utils/logger";
+import {
+  getSpeciesNeedingExternalSync,
+  recordExternalDataSync,
+} from "@/db/external-data-sync";
+import {
+  getSpeciesExternalReferences,
+  setSpeciesExternalReferences,
+  getSpeciesImages,
+  setSpeciesImages,
+} from "@/db/species";
+import { getWikipediaClient } from "@/integrations/wikipedia";
+import { getGBIFClient } from "@/integrations/gbif";
+
+/**
+ * Production-runnable external-data sync, extracted from the standalone
+ * scripts/sync-*-all-species.ts so it can run inside the app (the prod image
+ * has no ts-node and doesn't ship scripts/).
+ *
+ * v1 scope: Wikipedia + GBIF reference links and (external) image URLs, over
+ * species whose data is stale (>90 days) or never synced. FishBase (DuckDB +
+ * parquet) and R2 image download/transcode are intentionally deferred — see
+ * the per-source scripts for those, which remain available for CLI backfill.
+ */
+
+// Only the method we call, so tests can inject fakes without real HTTP.
+interface SourceClient<T> {
+  getExternalData(genus: string, species: string): Promise<T | null>;
+}
+interface WikipediaData {
+  wikidataUrl: string;
+  wikipediaUrls: Record<string, string>;
+  imageUrls: string[];
+}
+interface GBIFData {
+  gbifUrl: string;
+  occurrenceMapUrl: string;
+  imageUrls: string[];
+}
+export interface EnrichmentClients {
+  wikipedia: SourceClient<WikipediaData>;
+  gbif: SourceClient<GBIFData>;
+}
+
+export interface SyncOptions {
+  /** Max species processed per run (bounds a manual run). Default 50. */
+  limit?: number;
+  /** Staleness threshold in days. Default 90. */
+  daysOld?: number;
+  /** Also store external image URLs (no R2 download in v1). Default true. */
+  withImages?: boolean;
+}
+
+export interface SyncSummary {
+  processed: number;
+  linksAdded: number;
+  imagesAdded: number;
+  notFound: number;
+  errors: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_DAYS_OLD = 90;
+const WIKIPEDIA_DELAY_MS = 150;
+const GBIF_DELAY_MS = 120;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const errMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+const defaultClients = (): EnrichmentClients => ({
+  wikipedia: getWikipediaClient(),
+  gbif: getGBIFClient(),
+});
+
+/** Add only URLs not already present (the set* helpers replace, so we merge). */
+async function addReferences(groupId: number, urls: string[]): Promise<number> {
+  const candidates = urls.filter((u) => u && u.length > 0);
+  if (candidates.length === 0) return 0;
+  const existing = await getSpeciesExternalReferences(groupId);
+  const existingUrls = existing.map((r) => r.reference_url);
+  const existingSet = new Set(existingUrls);
+  const toAdd = candidates.filter((u) => !existingSet.has(u));
+  if (toAdd.length === 0) return 0;
+  await setSpeciesExternalReferences(groupId, [...existingUrls, ...toAdd]);
+  return toAdd.length;
+}
+
+async function addImages(groupId: number, urls: string[]): Promise<number> {
+  const candidates = urls.filter((u) => u && u.length > 0);
+  if (candidates.length === 0) return 0;
+  const existing = await getSpeciesImages(groupId);
+  const existingUrls = existing.map((i) => i.image_url);
+  const existingSet = new Set(existingUrls);
+  const toAdd = candidates.filter((u) => !existingSet.has(u));
+  if (toAdd.length === 0) return 0;
+  await setSpeciesImages(groupId, [...existingUrls, ...toAdd]);
+  return toAdd.length;
+}
+
+/**
+ * Run one sync pass. Returns a summary. Safe to call directly (tests inject
+ * fake clients) or via startExternalDataSync() for fire-and-forget.
+ */
+export async function runExternalDataSync(
+  options: SyncOptions = {},
+  clients: EnrichmentClients = defaultClients()
+): Promise<SyncSummary> {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const daysOld = options.daysOld ?? DEFAULT_DAYS_OLD;
+  const withImages = options.withImages ?? true;
+
+  const summary: SyncSummary = {
+    processed: 0,
+    linksAdded: 0,
+    imagesAdded: 0,
+    notFound: 0,
+    errors: 0,
+  };
+
+  const candidates = (await getSpeciesNeedingExternalSync(writeConn, daysOld)).slice(0, limit);
+  logger.info(`External data sync starting: ${candidates.length} species (limit ${limit})`);
+
+  for (const sp of candidates) {
+    const groupId = sp.group_id;
+    const genus = sp.canonical_genus;
+    const species = sp.canonical_species_name;
+    summary.processed++;
+
+    // --- Wikipedia / Wikidata ---
+    try {
+      const wiki = await clients.wikipedia.getExternalData(genus, species);
+      if (wiki) {
+        const links = await addReferences(groupId, [
+          wiki.wikidataUrl,
+          ...Object.values(wiki.wikipediaUrls),
+        ]);
+        const images = withImages ? await addImages(groupId, wiki.imageUrls) : 0;
+        summary.linksAdded += links;
+        summary.imagesAdded += images;
+        await recordExternalDataSync(writeConn, groupId, "wikipedia", "success", links, images);
+      } else {
+        summary.notFound++;
+        await recordExternalDataSync(writeConn, groupId, "wikipedia", "not_found");
+      }
+    } catch (err) {
+      summary.errors++;
+      logger.warn("Wikipedia sync failed", { groupId, error: errMessage(err) });
+      await recordExternalDataSync(writeConn, groupId, "wikipedia", "error", 0, 0, errMessage(err));
+    }
+    await sleep(WIKIPEDIA_DELAY_MS);
+
+    // --- GBIF ---
+    try {
+      const gbif = await clients.gbif.getExternalData(genus, species);
+      if (gbif) {
+        const links = await addReferences(groupId, [gbif.gbifUrl, gbif.occurrenceMapUrl]);
+        const images = withImages ? await addImages(groupId, gbif.imageUrls) : 0;
+        summary.linksAdded += links;
+        summary.imagesAdded += images;
+        await recordExternalDataSync(writeConn, groupId, "gbif", "success", links, images);
+      } else {
+        summary.notFound++;
+        await recordExternalDataSync(writeConn, groupId, "gbif", "not_found");
+      }
+    } catch (err) {
+      summary.errors++;
+      logger.warn("GBIF sync failed", { groupId, error: errMessage(err) });
+      await recordExternalDataSync(writeConn, groupId, "gbif", "error", 0, 0, errMessage(err));
+    }
+    await sleep(GBIF_DELAY_MS);
+  }
+
+  logger.info("External data sync complete", { ...summary });
+  return summary;
+}
+
+// --- Fire-and-forget background runner (for the admin "Sync now" button) ---
+
+export interface SyncState {
+  running: boolean;
+  startedAt: string | null;
+  finishedAt: string | null;
+  lastSummary: SyncSummary | null;
+  lastError: string | null;
+}
+
+let state: SyncState = {
+  running: false,
+  startedAt: null,
+  finishedAt: null,
+  lastSummary: null,
+  lastError: null,
+};
+
+export function getExternalDataSyncState(): SyncState {
+  return { ...state };
+}
+
+/**
+ * Start a sync in the background and return immediately. Returns false if a
+ * sync is already running (single-flight). A run can take many minutes, so the
+ * caller must not await it — poll getExternalDataSyncState() instead.
+ */
+export function startExternalDataSync(options: SyncOptions = {}): boolean {
+  if (state.running) return false;
+
+  state = {
+    running: true,
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    lastSummary: null,
+    lastError: null,
+  };
+
+  void (async () => {
+    try {
+      const summary = await runExternalDataSync(options);
+      state = { ...state, running: false, finishedAt: new Date().toISOString(), lastSummary: summary };
+    } catch (err) {
+      logger.error("Background external data sync failed", err);
+      state = { ...state, running: false, finishedAt: new Date().toISOString(), lastError: errMessage(err) };
+    }
+  })();
+
+  return true;
+}

--- a/src/views/admin/adminActionsPanel.pug
+++ b/src/views/admin/adminActionsPanel.pug
@@ -57,3 +57,9 @@ mixin adminActionsPanel(witnessCount, approvalsCount, witnessProgram, approvalsP
 				role="menuitem")
 				.flex.items-center.justify-between.w-full
 					span Live Display Settings
+
+			a.admin-menu-item(
+				href="/admin/external-data"
+				role="menuitem")
+				.flex.items-center.justify-between.w-full
+					span External Data Sync

--- a/src/views/admin/externalData.pug
+++ b/src/views/admin/externalData.pug
@@ -1,0 +1,18 @@
+include ../header.pug
+
+doctype html
+html
+  +headTag('External Data Sync')
+  body.bg-white.text-gray-800
+    +pageHeader(true, 'External Data Sync')
+
+    section.bg-gray-100.py-8
+      div(class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8")
+        .bg-white.rounded-lg.shadow.p-6
+          h2.text-xl.font-bold.mb-2.text-gray-900 Species Data Enrichment
+          p.text-gray-600.mb-6
+            | Pulls reference links and images from Wikipedia and GBIF for species whose
+            | data is stale (older than 90 days) or never synced. A manual run processes up
+            | to 25 species in the background; this page polls for progress.
+
+          include externalDataStatus.pug

--- a/src/views/admin/externalDataStatus.pug
+++ b/src/views/admin/externalDataStatus.pug
@@ -1,0 +1,76 @@
+mixin statusBadge(status)
+  - const colors = { success: 'bg-green-100 text-green-800', not_found: 'bg-gray-100 text-gray-700', error: 'bg-red-100 text-red-800', skipped: 'bg-yellow-100 text-yellow-800' }
+  span(class=`inline-block px-2 py-0.5 rounded text-xs font-medium ${colors[status] || 'bg-gray-100 text-gray-700'}`)= status
+
+#sync-status
+  if state.running
+    //- Poll while a run is in progress
+    .bg-blue-50.border.border-blue-200.rounded-lg.p-4.mb-4(
+      hx-get="/admin/external-data/status"
+      hx-trigger="every 5s"
+      hx-target="#sync-status"
+      hx-swap="outerHTML"
+    )
+      .flex.items-center.gap-3
+        .animate-spin.h-5.w-5.border-2.border-blue-500.border-t-transparent.rounded-full
+        div
+          p.font-semibold.text-blue-900 Sync running…
+          if state.startedAt
+            p.text-sm.text-blue-700 Started #{new Date(state.startedAt).toLocaleString()}
+  else
+    .bg-gray-50.border.border-gray-200.rounded-lg.p-4.mb-4
+      .flex.items-center.justify-between.gap-4
+        div
+          if state.lastError
+            p.font-semibold.text-red-800 Last run failed
+            p.text-sm.text-red-700= state.lastError
+          else if state.lastSummary
+            p.font-semibold.text-gray-900 Last run complete
+            p.text-sm.text-gray-700
+              | processed #{state.lastSummary.processed} · links +#{state.lastSummary.linksAdded} · images +#{state.lastSummary.imagesAdded} · not found #{state.lastSummary.notFound} · errors #{state.lastSummary.errors}
+          else
+            p.font-semibold.text-gray-900 Idle
+            p.text-sm.text-gray-600 No sync run this session.
+        button.primary(
+          hx-post="/admin/external-data/sync"
+          hx-target="#sync-status"
+          hx-swap="outerHTML"
+        ) Sync now
+
+  //- Coverage stats
+  .grid.grid-cols-2.gap-4.my-4(class="sm:grid-cols-4")
+    .bg-white.border.border-gray-200.rounded-lg.p-3.text-center
+      .text-2xl.font-bold.text-gray-900= stats.total_species
+      .text-xs.text-gray-600 Species
+    .bg-white.border.border-gray-200.rounded-lg.p-3.text-center
+      .text-2xl.font-bold.text-gray-900= stats.species_with_external_links
+      .text-xs.text-gray-600 With links
+    .bg-white.border.border-gray-200.rounded-lg.p-3.text-center
+      .text-2xl.font-bold.text-gray-900= stats.species_with_images
+      .text-xs.text-gray-600 With images
+    .bg-white.border.border-gray-200.rounded-lg.p-3.text-center
+      .text-2xl.font-bold.text-gray-900= stats.successful_syncs
+      .text-xs.text-gray-600 Successful syncs
+
+  //- Recent activity
+  h3.font-bold.text-gray-900.mt-6.mb-2 Recent sync activity
+  if recentLog.length === 0
+    p.text-sm.text-gray-600 No sync activity recorded yet.
+  else
+    .overflow-x-auto
+      table.w-full.text-sm.bg-white.rounded-lg.shadow-sm
+        thead
+          tr.bg-gray-50
+            th.p-2.text-left.border-b Source
+            th.p-2.text-left.border-b Status
+            th.p-2.text-right.border-b Links
+            th.p-2.text-right.border-b Images
+            th.p-2.text-left.border-b When
+        tbody
+          each entry in recentLog
+            tr.border-b.border-gray-100
+              td.p-2= entry.source
+              td.p-2: +statusBadge(entry.status)
+              td.p-2.text-right= entry.links_added
+              td.p-2.text-right= entry.images_added
+              td.p-2.text-gray-600= new Date(entry.sync_date).toLocaleString()


### PR DESCRIPTION
Part of #249 — makes the species external-data sync **runnable in production** and adds a manual trigger. (Kept open: automatic schedule, FishBase, and R2 image download are deferred — see scope below.)

## Why this isn't just "wire up a cron"
The standalone `scripts/sync-*-all-species.ts` can't run on Fly: the prod image is `npm ci --omit=dev` (no ts-node/tsx) and doesn't ship `scripts/`. The DB also lives on a single-machine Fly volume, so the sync must run on the web machine. So the core loop is **extracted into a `src/` service** that the app can call directly.

## What's here
- **`src/services/externalDataSync.ts`** — `runExternalDataSync()` drives the existing `src/integrations` clients + `src/db` layer (`getSpeciesNeedingExternalSync`, `recordExternalDataSync`, `get/setSpeciesExternalReferences/Images`) over species stale >90d or never synced. Additive merge of links/images, per-source logging, rate-limited (150ms Wikipedia / 120ms GBIF), bounded by `limit`. Plus a single-flight, fire-and-forget runner (`startExternalDataSync`) with status — a run takes minutes, so the admin can't hold an HTTP request open.
- **Admin UI** — `GET /admin/external-data` (page), `GET …/status` (HTMX poll), `POST …/sync` (trigger). Coverage stats + last-run summary + recent sync log; "Sync now" button with 5s polling while running. Linked from the admin actions panel.
- **Tests** — service: per-source success/not-found/error, additive merge, stale-skip on re-run, limit. Plus render coverage for the new page.

## Scope (you chose "manual trigger first")
**In:** Wikipedia + GBIF; reference links + external image URLs; manual admin trigger.
**Deferred:** FishBase (DuckDB/parquet — and its `download-cache.ts` is missing, a separate broken pipeline), R2 image download/transcode, and an automatic daily/weekly schedule. The CLI scripts remain for power-user backfill.

## Verification
`tsc`, lint, full suite **1002/0** (node 22). Status partial render-checked in idle + running states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)