### PR TITLE
feat(security): full CSRF protection + session hardening — all 3 phases (#19)

### DIFF
--- a/db/migrations/055-add-session-csrf-token.sql
+++ b/db/migrations/055-add-session-csrf-token.sql
@@ -1,0 +1,23 @@
+-- Up
+
+-- Issue #19 Phase 2: defense-in-depth synchronizer CSRF token.
+--
+-- Each session carries a high-entropy CSRF token. The server surfaces it into
+-- authenticated pages via a <meta> tag; the browser echoes it back on every
+-- state-changing request (X-CSRF-Token header / _csrf field) where it is
+-- compared against this stored value. This backs up the Phase 1 Origin/Referer
+-- check, closing the sibling-subdomain SameSite carve-out with a second,
+-- independent control.
+
+ALTER TABLE sessions ADD COLUMN csrf_token TEXT;
+
+-- Backfill existing sessions so logged-in users aren't forced to re-auth on
+-- deploy. randomblob(32) -> 64 hex chars, matching newly-issued tokens.
+UPDATE sessions
+SET csrf_token = lower(hex(randomblob(32)))
+WHERE csrf_token IS NULL;
+
+-- Down
+
+-- SQLite can't DROP COLUMN cleanly on older versions; leaving the column is
+-- harmless if rolled back.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,6 +1170,28 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -3848,7 +3870,6 @@
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
 			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -3918,7 +3939,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
 			"integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -4050,7 +4070,6 @@
 			"integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.62.0",
 				"@typescript-eslint/types": "8.62.0",
@@ -4300,7 +4319,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4824,7 +4842,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.38",
 				"caniuse-lite": "^1.0.30001799",
@@ -5863,7 +5880,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6131,7 +6147,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
 			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.0",
@@ -8550,7 +8565,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -10044,7 +10058,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -10182,7 +10195,6 @@
 			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -10264,7 +10276,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -10654,7 +10665,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"csv-parse": "^6.1.0",
 				"express": "^5.1.0",
 				"express-rate-limit": "^8.0.1",
+				"helmet": "^8.2.0",
 				"marked": "^17.0.0",
 				"module-alias": "^2.2.3",
 				"multer": "^2.0.1",
@@ -1167,28 +1168,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -3869,6 +3848,7 @@
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
 			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -3938,6 +3918,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
 			"integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -4069,6 +4050,7 @@
 			"integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.62.0",
 				"@typescript-eslint/types": "8.62.0",
@@ -4318,6 +4300,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4841,6 +4824,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.38",
 				"caniuse-lite": "^1.0.30001799",
@@ -5879,6 +5863,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6146,6 +6131,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
 			"integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.0",
@@ -6797,6 +6783,18 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/helmet": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+			"integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/EvanHahn"
 			}
 		},
 		"node_modules/hono": {
@@ -8552,6 +8550,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -10045,6 +10044,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -10182,6 +10182,7 @@
 			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -10263,6 +10264,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -10652,6 +10654,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"csv-parse": "^6.1.0",
 		"express": "^5.1.0",
 		"express-rate-limit": "^8.0.1",
+		"helmet": "^8.2.0",
 		"marked": "^17.0.0",
 		"module-alias": "^2.2.3",
 		"multer": "^2.0.1",

--- a/public/js/csrf.js
+++ b/public/js/csrf.js
@@ -1,0 +1,55 @@
+// Issue #19 Phase 2 — client-side CSRF token delivery.
+//
+// Reads the per-session token from <meta name="csrf-token"> (rendered into
+// authenticated pages) and echoes it back on every same-origin, state-changing
+// request as the `X-CSRF-Token` header. Covers both HTMX requests and raw
+// fetch() calls (image upload, passkey registration, collection images) so no
+// individual call site needs to be touched.
+(function () {
+  "use strict";
+
+  var meta = document.querySelector('meta[name="csrf-token"]');
+  var token = meta ? meta.getAttribute("content") : null;
+  if (!token) {
+    // Anonymous pages have no token; nothing to attach.
+    return;
+  }
+  window.csrfToken = token;
+
+  var UNSAFE = /^(POST|PUT|PATCH|DELETE)$/i;
+
+  // HTMX: hx-post / hx-patch / hx-delete all fire this event before sending.
+  document.addEventListener("htmx:configRequest", function (evt) {
+    if (evt.detail && evt.detail.headers && UNSAFE.test(evt.detail.verb || "")) {
+      evt.detail.headers["X-CSRF-Token"] = token;
+    }
+  });
+
+  // fetch(): wrap so same-origin mutating requests carry the header too.
+  if (typeof window.fetch === "function") {
+    var originalFetch = window.fetch.bind(window);
+    window.fetch = function (input, init) {
+      init = init || {};
+      var method =
+        (init.method ||
+          (typeof input !== "string" && input && input.method) ||
+          "GET").toUpperCase();
+
+      var url = typeof input === "string" ? input : (input && input.url) || "";
+      // Same-origin if relative (no scheme) or it starts with our origin.
+      var isAbsolute = /^[a-z][a-z0-9+.-]*:\/\//i.test(url);
+      var sameOrigin = !isAbsolute || url.indexOf(window.location.origin) === 0;
+
+      if (sameOrigin && UNSAFE.test(method)) {
+        var headers = new Headers(
+          init.headers || (typeof input !== "string" && input && input.headers) || {}
+        );
+        if (!headers.has("X-CSRF-Token")) {
+          headers.set("X-CSRF-Token", token);
+        }
+        init.headers = headers;
+      }
+      return originalFetch(input, init);
+    };
+  }
+})();

--- a/src/__tests__/csrfValidation.test.ts
+++ b/src/__tests__/csrfValidation.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert";
+import express from "express";
+import request from "supertest";
+import { csrfValidation } from "../middleware/csrfValidation";
+import { MulmRequest } from "../sessions";
+
+const TOKEN = "valid-session-token";
+
+/**
+ * Build an app where a query flag drives the simulated auth state:
+ *   ?auth=1        -> authenticated with a csrf_token
+ *   ?auth=notoken  -> authenticated but no stored token (legacy session)
+ *   (default)      -> unauthenticated
+ */
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+  app.use((req: MulmRequest, _res, next) => {
+    const auth = req.query.auth;
+    if (auth === "1") {
+      req.viewer = { id: 7, display_name: "T", contact_email: "t@e.com" };
+      req.csrfToken = TOKEN;
+    } else if (auth === "notoken") {
+      req.viewer = { id: 7, display_name: "T", contact_email: "t@e.com" };
+    }
+    next();
+  });
+  app.use(csrfValidation);
+  const ok = (_req: express.Request, res: express.Response) => res.status(200).send("ok");
+  app.get("/thing", ok);
+  app.post("/thing", ok);
+  app.patch("/thing", ok);
+  app.delete("/thing", ok);
+  return app;
+}
+
+void describe("CSRF token validation middleware", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = makeApp();
+  });
+
+  void test("allows an authenticated POST with a matching X-CSRF-Token header", async () => {
+    await request(app).post("/thing?auth=1").set("X-CSRF-Token", TOKEN).expect(200);
+  });
+
+  void test("allows an authenticated POST with a matching _csrf body field", async () => {
+    await request(app)
+      .post("/thing?auth=1")
+      .send({ _csrf: TOKEN })
+      .expect(200);
+  });
+
+  void test("rejects an authenticated POST with no token", async () => {
+    const res = await request(app).post("/thing?auth=1");
+    assert.strictEqual(res.status, 403);
+  });
+
+  void test("rejects an authenticated POST with a wrong token", async () => {
+    const res = await request(app).post("/thing?auth=1").set("X-CSRF-Token", "nope");
+    assert.strictEqual(res.status, 403);
+  });
+
+  void test("skips unauthenticated requests (covered by Origin validation)", async () => {
+    await request(app).post("/thing").expect(200);
+  });
+
+  void test("does not block authenticated sessions that have no stored token", async () => {
+    await request(app).post("/thing?auth=notoken").expect(200);
+  });
+
+  void test("ignores safe methods even when authenticated", async () => {
+    await request(app).get("/thing?auth=1").expect(200);
+  });
+
+  void test("applies to PATCH", async () => {
+    await request(app).patch("/thing?auth=1").set("X-CSRF-Token", TOKEN).expect(200);
+    const res = await request(app).patch("/thing?auth=1");
+    assert.strictEqual(res.status, 403);
+  });
+
+  void test("applies to DELETE", async () => {
+    await request(app).delete("/thing?auth=1").set("X-CSRF-Token", TOKEN).expect(200);
+    const res = await request(app).delete("/thing?auth=1");
+    assert.strictEqual(res.status, 403);
+  });
+});

--- a/src/__tests__/db-small-modules.test.ts
+++ b/src/__tests__/db-small-modules.test.ts
@@ -304,12 +304,13 @@ void describe("sessions.ts", () => {
 
   void describe("regenerateSessionInDB", () => {
     void test("should create a new session", async () => {
-      await regenerateSessionInDB(undefined, "new-session-1", memberId1, "2030-01-01T00:00:00Z");
+      await regenerateSessionInDB(undefined, "new-session-1", memberId1, "2030-01-01T00:00:00Z", "csrf-1");
 
       const row = await db.get("SELECT * FROM sessions WHERE session_id = ?", "new-session-1");
       assert.ok(row);
       assert.equal(row.member_id, memberId1);
       assert.equal(row.expires_on, "2030-01-01T00:00:00Z");
+      assert.equal(row.csrf_token, "csrf-1");
     });
 
     void test("should delete old session and create new one", async () => {
@@ -319,7 +320,7 @@ void describe("sessions.ts", () => {
         ["old-session", memberId1, "2030-01-01T00:00:00Z"]
       );
 
-      await regenerateSessionInDB("old-session", "new-session", memberId1, "2031-01-01T00:00:00Z");
+      await regenerateSessionInDB("old-session", "new-session", memberId1, "2031-01-01T00:00:00Z", "csrf-2");
 
       const old = await db.get("SELECT * FROM sessions WHERE session_id = ?", "old-session");
       const newS = await db.get("SELECT * FROM sessions WHERE session_id = ?", "new-session");
@@ -330,7 +331,7 @@ void describe("sessions.ts", () => {
 
     void test("should handle undefined old session ID gracefully", async () => {
       await assert.doesNotReject(async () => {
-        await regenerateSessionInDB(undefined, "fresh-session", memberId1, "2030-01-01T00:00:00Z");
+        await regenerateSessionInDB(undefined, "fresh-session", memberId1, "2030-01-01T00:00:00Z", "csrf-3");
       });
 
       const row = await db.get("SELECT * FROM sessions WHERE session_id = ?", "fresh-session");
@@ -343,7 +344,8 @@ void describe("sessions.ts", () => {
           "undefined",
           "session-after-undef",
           memberId1,
-          "2030-01-01T00:00:00Z"
+          "2030-01-01T00:00:00Z",
+          "csrf-4"
         );
       });
 
@@ -360,7 +362,7 @@ void describe("sessions.ts", () => {
         ["existing", memberId1, "2030-01-01T00:00:00Z"]
       );
 
-      await regenerateSessionInDB("existing", "replacement", memberId1, "2031-06-15T12:00:00Z");
+      await regenerateSessionInDB("existing", "replacement", memberId1, "2031-06-15T12:00:00Z", "csrf-5");
 
       const count = await db.get("SELECT COUNT(*) as cnt FROM sessions WHERE member_id = ?", memberId1);
       assert.equal(count.cnt, 1);

--- a/src/__tests__/originValidation.test.ts
+++ b/src/__tests__/originValidation.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert";
+import express from "express";
+import request from "supertest";
+import { createOriginValidation, buildAllowedOrigins } from "../middleware/originValidation";
+
+const ALLOWED = "https://bap.basny.org";
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(createOriginValidation({ allowedOrigins: [ALLOWED] }));
+  // Echo handlers for every method we care about.
+  const ok = (_req: express.Request, res: express.Response) => res.status(200).send("ok");
+  app.get("/thing", ok);
+  app.post("/thing", ok);
+  app.patch("/thing", ok);
+  app.delete("/thing", ok);
+  app.put("/thing", ok);
+  return app;
+}
+
+void describe("Origin/Referer validation middleware", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = makeApp();
+  });
+
+  void describe("state-changing requests", () => {
+    void test("allows POST with an allowlisted Origin", async () => {
+      await request(app).post("/thing").set("Origin", ALLOWED).expect(200);
+    });
+
+    void test("rejects POST with a cross-origin Origin", async () => {
+      const res = await request(app).post("/thing").set("Origin", "https://evil.example.com");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("rejects POST from a sibling subdomain (SameSite carve-out)", async () => {
+      const res = await request(app).post("/thing").set("Origin", "https://evil.basny.org");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("rejects a literal 'null' Origin", async () => {
+      const res = await request(app).post("/thing").set("Origin", "null");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("rejects when both Origin and Referer are absent", async () => {
+      const res = await request(app).post("/thing");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("falls back to an allowlisted Referer when Origin is absent", async () => {
+      await request(app).post("/thing").set("Referer", `${ALLOWED}/some/page`).expect(200);
+    });
+
+    void test("rejects a cross-origin Referer when Origin is absent", async () => {
+      const res = await request(app).post("/thing").set("Referer", "https://evil.example.com/page");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("rejects a malformed Referer", async () => {
+      const res = await request(app).post("/thing").set("Referer", "not a url");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("prefers Origin over Referer (bad Origin rejected even with good Referer)", async () => {
+      const res = await request(app)
+        .post("/thing")
+        .set("Origin", "https://evil.example.com")
+        .set("Referer", `${ALLOWED}/page`);
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("allows same-origin requests via the request's own host", async () => {
+      // No static allowlist entry for example.com; matched via self-origin.
+      await request(app)
+        .post("/thing")
+        .set("Host", "example.com")
+        .set("Origin", "http://example.com")
+        .expect(200);
+    });
+
+    void test("applies to PATCH", async () => {
+      await request(app).patch("/thing").set("Origin", ALLOWED).expect(200);
+      const res = await request(app).patch("/thing").set("Origin", "https://evil.example.com");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("applies to DELETE", async () => {
+      await request(app).delete("/thing").set("Origin", ALLOWED).expect(200);
+      const res = await request(app).delete("/thing").set("Origin", "https://evil.example.com");
+      assert.strictEqual(res.status, 403);
+    });
+
+    void test("applies to PUT", async () => {
+      await request(app).put("/thing").set("Origin", ALLOWED).expect(200);
+      const res = await request(app).put("/thing").set("Origin", "https://evil.example.com");
+      assert.strictEqual(res.status, 403);
+    });
+  });
+
+  void describe("safe methods", () => {
+    void test("GET is never checked, even cross-origin", async () => {
+      await request(app).get("/thing").set("Origin", "https://evil.example.com").expect(200);
+    });
+
+    void test("GET with no headers passes", async () => {
+      await request(app).get("/thing").expect(200);
+    });
+  });
+
+  void describe("buildAllowedOrigins", () => {
+    void test("includes localhost variants in non-production", () => {
+      // Tests run with NODE_ENV=test.
+      const origins = buildAllowedOrigins();
+      assert.ok(origins.has("http://localhost:4200"));
+      assert.ok(origins.has("http://127.0.0.1:4200"));
+    });
+
+    void test("honors the ALLOWED_ORIGINS env override", () => {
+      const prev = process.env.ALLOWED_ORIGINS;
+      process.env.ALLOWED_ORIGINS = "https://staging.example.com, https://preview.example.com";
+      try {
+        const origins = buildAllowedOrigins();
+        assert.ok(origins.has("https://staging.example.com"));
+        assert.ok(origins.has("https://preview.example.com"));
+      } finally {
+        if (prev === undefined) {
+          delete process.env.ALLOWED_ORIGINS;
+        } else {
+          process.env.ALLOWED_ORIGINS = prev;
+        }
+      }
+    });
+  });
+});

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -7,7 +7,8 @@ export async function regenerateSessionInDB(
   oldSessionId: string | undefined,
   newSessionId: string,
   memberId: number,
-  expiresOn: string
+  expiresOn: string,
+  csrfToken: string
 ): Promise<void> {
   await withTransaction(async (db) => {
     // Delete old session if it exists
@@ -22,11 +23,11 @@ export async function regenerateSessionInDB(
 
     // Create new session
     const insertStmt = await db.prepare(`
-      INSERT INTO sessions (session_id, member_id, expires_on)
-      VALUES (?, ?, ?);
+      INSERT INTO sessions (session_id, member_id, expires_on, csrf_token)
+      VALUES (?, ?, ?, ?);
     `);
     try {
-      await insertStmt.run(newSessionId, memberId, expiresOn);
+      await insertStmt.run(newSessionId, memberId, expiresOn, csrfToken);
     } finally {
       await insertStmt.finalize();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,13 @@ import {
   MulmRequest,
   sessionMiddleware,
   generateSessionCookie,
+  generateCsrfToken,
   SESSION_COOKIE_NAME,
   SESSION_MAX_AGE_MS,
   sessionCookieOptions,
 } from "./sessions";
 import { originValidation } from "./middleware/originValidation";
+import { csrfValidation } from "./middleware/csrfValidation";
 import helmet from "helmet";
 import { getGoogleOAuthURL, getFacebookOAuthURL, setOAuthStateCookie, isGoogleOAuthEnabled, isFacebookOAuthEnabled } from "./oauth";
 import { getQueryString, getBodyString } from "./utils/request";
@@ -79,6 +81,47 @@ if (process.env.NODE_ENV === "production") {
 app.use(helmet.frameguard({ action: "deny" }));
 app.use(helmet.noSniff());
 
+// Content-Security-Policy in Report-Only mode (issue #19 Phase 3, first step).
+// Report-Only surfaces violations of the *target* policy without blocking, so
+// the inline scripts/handlers that currently power the UI can be found and
+// refactored before CSP is enforced. Enforcing today would break the app.
+//
+// The report collector is registered before the Origin/CSRF middleware (below)
+// so browser-sent reports — which carry no Origin or CSRF token — aren't rejected.
+app.post(
+  "/csp-report",
+  express.json({
+    type: ["application/csp-report", "application/reports+json", "application/json"],
+    limit: "64kb",
+  }),
+  (req, res) => {
+    logger.warn("CSP violation report", { report: req.body as unknown });
+    res.status(204).end();
+  }
+);
+
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: false,
+    reportOnly: true,
+    directives: {
+      defaultSrc: ["'self'"],
+      // esm.sh serves the SimpleWebAuthn passkey browser helper.
+      scriptSrc: ["'self'", "https://esm.sh"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      // R2-hosted submission images + Open Graph images over https; data: for inline svg.
+      imgSrc: ["'self'", "data:", "https:"],
+      connectSrc: ["'self'", "https://esm.sh"],
+      fontSrc: ["'self'", "data:"],
+      objectSrc: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"],
+      frameAncestors: ["'none'"],
+      reportUri: ["/csp-report"],
+    },
+  })
+);
+
 // Initialize R2 client for image uploads
 initR2();
 
@@ -104,6 +147,11 @@ app.use(sessionMiddleware);
 // gap closed by issue #19 — it makes our `SameSite=Lax` cookie sufficient even
 // against the sibling-subdomain SameSite carve-out.
 app.use(originValidation);
+
+// Defense-in-depth (issue #19 Phase 2): synchronizer-token CSRF check on
+// authenticated state-changing requests. Runs after sessionMiddleware so
+// req.viewer / req.csrfToken are populated.
+app.use(csrfValidation);
 
 // Make config available to all templates via res.locals
 app.use((_req, res, next) => {
@@ -362,11 +410,12 @@ router.post("/test-login", devOnly, async (req, res) => {
     }
 
     // Create new session
+    const csrfToken = generateCsrfToken();
     const insertStmt = await writeConn.prepare(
-      "INSERT INTO sessions (session_id, member_id, expires_on) VALUES (?, ?, ?)"
+      "INSERT INTO sessions (session_id, member_id, expires_on, csrf_token) VALUES (?, ?, ?, ?)"
     );
     try {
-      await insertStmt.run(sessionId, member.id, expiry);
+      await insertStmt.run(sessionId, member.id, expiry, csrfToken);
     } finally {
       await insertStmt.finalize();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,16 @@ import { getMemberByEmail, getMemberPassword } from "./db/members";
 import { checkPassword } from "./auth";
 import { ready, writeConn } from "./db/conn";
 
-import { MulmRequest, sessionMiddleware, generateSessionCookie } from "./sessions";
+import {
+  MulmRequest,
+  sessionMiddleware,
+  generateSessionCookie,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_MS,
+  sessionCookieOptions,
+} from "./sessions";
+import { originValidation } from "./middleware/originValidation";
+import helmet from "helmet";
 import { getGoogleOAuthURL, getFacebookOAuthURL, setOAuthStateCookie, isGoogleOAuthEnabled, isFacebookOAuthEnabled } from "./oauth";
 import { getQueryString, getBodyString } from "./utils/request";
 import { initR2 } from "./utils/r2-client";
@@ -52,6 +61,24 @@ const app = express();
 // Security: Hide Express version from X-Powered-By header
 app.disable("x-powered-by");
 
+// Behind Fly's proxy in production, trust the single proxy hop so req.protocol,
+// req.hostname and req.ip reflect the client-facing X-Forwarded-* values. We
+// trust exactly one hop (not `true`) so clients can't spoof X-Forwarded-For
+// past Fly's edge (matters for IP-keyed rate limiting and Origin validation).
+// https://fly.io/docs/networking/request-headers/
+if (process.env.NODE_ENV === "production") {
+  app.set("trust proxy", 1);
+}
+
+// Security headers (non-CSP subset only — CSP is deferred to issue #19 Phase 3,
+// blocked by existing inline JS). HSTS only in production (HTTPS); clickjacking
+// + MIME-sniffing protections everywhere.
+if (process.env.NODE_ENV === "production") {
+  app.use(helmet.hsts({ maxAge: 15552000 })); // 180 days
+}
+app.use(helmet.frameguard({ action: "deny" }));
+app.use(helmet.noSniff());
+
 // Initialize R2 client for image uploads
 initR2();
 
@@ -71,6 +98,12 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use(cookieParser());
 app.use(sessionMiddleware);
+
+// CSRF backstop: reject state-changing requests (POST/PUT/PATCH/DELETE) whose
+// Origin/Referer isn't an allowlisted, same-site origin. This is the primary
+// gap closed by issue #19 — it makes our `SameSite=Lax` cookie sufficient even
+// against the sibling-subdomain SameSite carve-out.
+app.use(originValidation);
 
 // Make config available to all templates via res.locals
 app.use((_req, res, next) => {
@@ -286,16 +319,16 @@ router.get("/dialog/auth/forgot-password", (req, res) => {
 
 // Test-only login page (simpler, no HTMX, for e2e tests)
 // Available in dev/test environments for reliable automated testing
-router.get("/test-login", (req, res) => {
+router.get("/test-login", devOnly, (req, res) => {
   res.render("test-login", { error: null });
 });
 
-router.post("/test-login", async (req, res) => {
+router.post("/test-login", devOnly, async (req, res) => {
   // Simplified test login - no lockout check, no timing attack mitigation
   const email = getBodyString(req, "email");
   const password = getBodyString(req, "password");
   const cookies = req.cookies as Record<string, string> | undefined;
-  const oldSessionId = cookies?.session_id || "";
+  const oldSessionId = cookies?.[SESSION_COOKIE_NAME] || "";
 
   const member = await getMemberByEmail(email);
 
@@ -316,7 +349,7 @@ router.post("/test-login", async (req, res) => {
   if (isValid) {
     // Create session manually without nested transactions
     const sessionId = generateSessionCookie();
-    const expiry = new Date(Date.now() + 180 * 86400 * 1000).toISOString();
+    const expiry = new Date(Date.now() + SESSION_MAX_AGE_MS).toISOString();
 
     // Delete old session if exists
     if (oldSessionId && oldSessionId !== "undefined") {
@@ -339,12 +372,7 @@ router.post("/test-login", async (req, res) => {
     }
 
     // Set cookie
-    res.cookie("session_id", sessionId, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 180 * 86400 * 1000,
-    });
+    res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions());
 
     res.redirect("/");
     return;
@@ -353,15 +381,16 @@ router.post("/test-login", async (req, res) => {
   res.render("test-login", { error: "Invalid email or password" });
 });
 
-router.get("/test-logout", async (req, res) => {
-  // Simple GET logout for e2e tests - destroys session and redirects
+router.get("/test-logout", devOnly, async (req, res) => {
+  // Simple GET logout for e2e tests - destroys session and redirects.
+  // Guarded by devOnly: a state-changing GET must not exist in production.
 
-  // Clear session cookie
-  res.cookie("session_id", "", { maxAge: 0 });
+  // Clear session cookie (matching attributes so the browser drops it)
+  res.clearCookie(SESSION_COOKIE_NAME, sessionCookieOptions(0));
 
   // Delete session from database
   const cookies = req.cookies as Record<string, string> | undefined;
-  const sessionId = cookies?.session_id || "";
+  const sessionId = cookies?.[SESSION_COOKIE_NAME] || "";
   if (sessionId && sessionId !== "undefined") {
     try {
       const deleteStmt = await writeConn.prepare("DELETE FROM sessions WHERE session_id = ?");

--- a/src/middleware/csrfValidation.ts
+++ b/src/middleware/csrfValidation.ts
@@ -1,0 +1,71 @@
+import { Response, NextFunction } from "express";
+import { MulmRequest } from "../sessions";
+import { logger } from "../utils/logger";
+
+/**
+ * Synchronizer-token CSRF validation — issue #19 Phase 2 (defense-in-depth on
+ * top of the Phase 1 Origin/Referer check).
+ *
+ * Each session has a high-entropy `csrf_token` (see migration 055). The server
+ * renders it into authenticated pages as `<meta name="csrf-token">`, and
+ * `/js/csrf.js` echoes it back on every state-changing request via the
+ * `X-CSRF-Token` header (covering both HTMX and raw `fetch`). This middleware
+ * compares the echoed token against the session's stored token.
+ *
+ * Scope:
+ * - Only state-changing methods are checked.
+ * - Only *authenticated* requests are checked — the token is issued at login,
+ *   so pre-auth mutations (login/signup/password reset, passkey login) have no
+ *   token yet and are already covered by Origin/Referer validation.
+ * - Legacy sessions with no stored token are not blocked (the migration
+ *   backfills tokens, but this guards against any gap).
+ */
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+function getProvidedToken(req: MulmRequest): string | undefined {
+  const header = req.get("x-csrf-token");
+  if (header) {
+    return header;
+  }
+  const body = req.body as { _csrf?: unknown } | undefined;
+  if (body && typeof body._csrf === "string") {
+    return body._csrf;
+  }
+  return undefined;
+}
+
+export function csrfValidation(req: MulmRequest, res: Response, next: NextFunction): void {
+  if (!STATE_CHANGING_METHODS.has(req.method)) {
+    next();
+    return;
+  }
+
+  // Unauthenticated requests carry no session token yet — Origin validation is
+  // the control there.
+  if (!req.viewer) {
+    next();
+    return;
+  }
+
+  const expected = req.csrfToken;
+  if (!expected) {
+    // Legacy/edge session without a stored token — can't validate, don't block.
+    next();
+    return;
+  }
+
+  const provided = getProvidedToken(req);
+  if (provided && provided === expected) {
+    next();
+    return;
+  }
+
+  logger.warn("Blocked request failing CSRF token validation", {
+    method: req.method,
+    path: req.path,
+    viewer: req.viewer.id,
+    hasToken: Boolean(provided),
+    ip: req.ip,
+  });
+  res.status(403).send("Forbidden: invalid or missing CSRF token");
+}

--- a/src/middleware/originValidation.ts
+++ b/src/middleware/originValidation.ts
@@ -1,0 +1,134 @@
+import { Request, Response, NextFunction } from "express";
+import config from "../config.json";
+import { logger } from "../utils/logger";
+
+/**
+ * Origin/Referer validation — the primary CSRF backstop for issue #19.
+ *
+ * `SameSite=Lax` on the session cookie is the main CSRF defense, but per current
+ * OWASP guidance it is only *sufficient* when the app also verifies the request
+ * Origin. This middleware closes that gap: every state-changing request must
+ * carry an `Origin` (or, as a fallback, `Referer`) header that resolves to a
+ * same-site origin. This also neutralizes the sibling-subdomain SameSite
+ * carve-out — a forged request from `evil.basny.org` carries that origin, which
+ * is not allowlisted, so it is rejected.
+ *
+ * Safe (non-state-changing) methods are not checked. GET/HEAD/OPTIONS must
+ * never mutate state (see issue #19's audit of GET routes).
+ */
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Build the statically-allowlisted origins. The request's own resolved origin
+ * (`${req.protocol}://${host}`) is always allowed in addition to these, which
+ * is what makes same-origin POSTs work without hardcoding the deploy domain —
+ * so this list is mainly for dev convenience and explicit extra origins.
+ */
+export function buildAllowedOrigins(): Set<string> {
+  const origins = new Set<string>();
+  const domain = config.server.domain;
+
+  if (process.env.NODE_ENV === "production") {
+    origins.add(`https://${domain}`);
+  } else {
+    // Dev/test: the app is served over plain HTTP on localhost.
+    origins.add(`http://${domain}`);
+    origins.add(`https://${domain}`);
+    origins.add("http://localhost:4200");
+    origins.add("http://127.0.0.1:4200");
+  }
+
+  // Optional comma-separated override for staging / additional deploy origins,
+  // e.g. ALLOWED_ORIGINS="https://staging.bap.basny.org,https://preview.example".
+  const extra = process.env.ALLOWED_ORIGINS;
+  if (extra) {
+    for (const entry of extra.split(",")) {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        origins.add(trimmed);
+      }
+    }
+  }
+
+  return origins;
+}
+
+export interface OriginValidationOptions {
+  /** Override the allowlist (primarily for tests). */
+  allowedOrigins?: Iterable<string>;
+}
+
+/**
+ * Create an Origin/Referer validation middleware. Exported as a factory so
+ * tests can inject a known allowlist; the app uses the default {@link originValidation}.
+ */
+export function createOriginValidation(options: OriginValidationOptions = {}) {
+  const allowlist = new Set(options.allowedOrigins ?? buildAllowedOrigins());
+
+  return function originValidation(req: Request, res: Response, next: NextFunction): void {
+    if (!STATE_CHANGING_METHODS.has(req.method)) {
+      next();
+      return;
+    }
+
+    // The origin this request was actually sent to. With `trust proxy` set,
+    // protocol/host reflect Fly's forwarded values. A forged cross-site request
+    // still targets our host but carries the *attacker's* Origin, so comparing
+    // against this self-origin is sound same-origin validation.
+    const host = req.get("host");
+    const selfOrigin = host ? `${req.protocol}://${host}` : undefined;
+    const isAllowed = (origin: string): boolean =>
+      allowlist.has(origin) || (selfOrigin !== undefined && origin === selfOrigin);
+
+    const reject = (reason: string): void => {
+      logger.warn("Blocked cross-origin state-changing request", {
+        reason,
+        method: req.method,
+        path: req.path,
+        origin: req.get("origin") ?? null,
+        referer: req.get("referer") ?? null,
+        ip: req.ip,
+      });
+      res.status(403).send("Forbidden: invalid request origin");
+    };
+
+    const originHeader = req.get("origin");
+    if (originHeader) {
+      // RFC 6454: a literal "null" Origin is an opaque/untrusted origin
+      // (sandboxed iframe, data:, redirect). Never trust it for mutations.
+      if (originHeader === "null") {
+        reject("null origin");
+        return;
+      }
+      if (isAllowed(originHeader)) {
+        next();
+        return;
+      }
+      reject("origin not allowlisted");
+      return;
+    }
+
+    // No Origin header (some same-origin requests omit it) — fall back to Referer.
+    const referer = req.get("referer");
+    if (referer) {
+      let refererOrigin: string;
+      try {
+        refererOrigin = new URL(referer).origin;
+      } catch {
+        reject("malformed referer");
+        return;
+      }
+      if (isAllowed(refererOrigin)) {
+        next();
+        return;
+      }
+      reject("referer not allowlisted");
+      return;
+    }
+
+    // A state-changing request with neither Origin nor Referer is rejected.
+    reject("missing origin and referer");
+  };
+}
+
+export const originValidation = createOriginValidation();

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -6,6 +6,9 @@ import { logger } from "./utils/logger";
 
 export const generateSessionCookie = () => generateRandomCode(64);
 
+/** Per-session CSRF token (issue #19 Phase 2): 32 random bytes, base64url. */
+export const generateCsrfToken = () => generateRandomCode(32);
+
 /**
  * Session lifetime. We deliberately keep the long-lived (180 day) cookie that
  * predates issue #19 — session IDs are rotated on every authentication event
@@ -55,12 +58,19 @@ type Viewer = {
   coral_level?: string;
 };
 
-export type MulmRequest = Request & { viewer?: Viewer };
+export type MulmRequest = Request & { viewer?: Viewer; csrfToken?: string };
 
-export async function sessionMiddleware(req: MulmRequest, _res: Response, next: NextFunction) {
+export async function sessionMiddleware(req: MulmRequest, res: Response, next: NextFunction) {
   const token = getSessionToken(req);
   if (token) {
-    req.viewer = await getLoggedInUser(token);
+    const session = await getLoggedInUser(token);
+    if (session) {
+      req.viewer = session;
+      req.csrfToken = session.csrf_token ?? undefined;
+      // Surface the CSRF token to templates so the layout can emit its
+      // <meta name="csrf-token"> tag (read back by /js/csrf.js).
+      res.locals.csrfToken = req.csrfToken;
+    }
   }
   next();
 }
@@ -74,7 +84,7 @@ function getSessionToken(req: Request): string {
 async function getLoggedInUser(token: string) {
   const now = new Date().toISOString();
   return (
-    await query<Viewer>(
+    await query<Viewer & { csrf_token: string | null }>(
       `
 				SELECT
 					members.id as id,
@@ -83,7 +93,8 @@ async function getLoggedInUser(token: string) {
 					members.is_admin as is_admin,
 					members.fish_level as fish_level,
 					members.plant_level as plant_level,
-					members.coral_level as coral_level
+					members.coral_level as coral_level,
+					sessions.csrf_token as csrf_token
 				FROM sessions JOIN members ON sessions.member_id = members.id
 				WHERE session_id = ? AND expires_on > ?;
 			`,
@@ -106,10 +117,11 @@ export async function regenerateSession(
 ): Promise<void> {
   const oldSessionId = getSessionToken(req);
   const newSessionId = generateSessionCookie();
+  const csrfToken = generateCsrfToken();
   const expiry = new Date(Date.now() + SESSION_MAX_AGE_MS).toISOString();
 
   // Delete old session and create new one atomically
-  await regenerateSessionInDB(oldSessionId, newSessionId, memberId, expiry);
+  await regenerateSessionInDB(oldSessionId, newSessionId, memberId, expiry, csrfToken);
 
   // Set new cookie
   res.cookie(SESSION_COOKIE_NAME, newSessionId, sessionCookieOptions());

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -6,6 +6,44 @@ import { logger } from "./utils/logger";
 
 export const generateSessionCookie = () => generateRandomCode(64);
 
+/**
+ * Session lifetime. We deliberately keep the long-lived (180 day) cookie that
+ * predates issue #19 — session IDs are rotated on every authentication event
+ * (see {@link regenerateSession}) which is the important fixation defense.
+ */
+export const SESSION_MAX_AGE_MS = 180 * 86400 * 1000;
+
+/**
+ * Name of the session cookie.
+ *
+ * In production we use the `__Host-` prefix. The browser only accepts a
+ * `__Host-`-prefixed cookie when it is `Secure`, has **no** `Domain`
+ * attribute, and uses `Path=/`. That gives us cheap, browser-enforced defense
+ * against subdomain cookie-forgery (a sibling `*.basny.org` can't set our
+ * session cookie) and HTTPS-downgrade attacks.
+ *
+ * The prefix *requires* `Secure`, so we cannot use it in dev/test where the app
+ * is served over plain HTTP on localhost — there we fall back to the bare name.
+ */
+export const SESSION_COOKIE_NAME =
+  process.env.NODE_ENV === "production" ? "__Host-session_id" : "session_id";
+
+/**
+ * Cookie options for the session cookie. Centralized so the set/clear sites
+ * stay in sync (clearing a cookie requires matching attributes). `path: "/"`
+ * and the production-only `secure` flag are also what the `__Host-` prefix
+ * requires.
+ */
+export function sessionCookieOptions(maxAgeMs: number = SESSION_MAX_AGE_MS) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: maxAgeMs,
+  };
+}
+
 type Viewer = {
   id: number;
   display_name: string;
@@ -20,11 +58,17 @@ type Viewer = {
 export type MulmRequest = Request & { viewer?: Viewer };
 
 export async function sessionMiddleware(req: MulmRequest, _res: Response, next: NextFunction) {
-  const token = String(req.cookies.session_id);
+  const token = getSessionToken(req);
   if (token) {
     req.viewer = await getLoggedInUser(token);
   }
   next();
+}
+
+/** Read the raw session token from the request cookies, or "" if absent. */
+function getSessionToken(req: Request): string {
+  const cookies = req.cookies as Record<string, string> | undefined;
+  return cookies?.[SESSION_COOKIE_NAME] ?? "";
 }
 
 async function getLoggedInUser(token: string) {
@@ -60,26 +104,27 @@ export async function regenerateSession(
   res: Response,
   memberId: number
 ): Promise<void> {
-  const oldSessionId = String(req.cookies.session_id);
+  const oldSessionId = getSessionToken(req);
   const newSessionId = generateSessionCookie();
-  const expiry = new Date(Date.now() + 180 * 86400 * 1000).toISOString();
+  const expiry = new Date(Date.now() + SESSION_MAX_AGE_MS).toISOString();
 
   // Delete old session and create new one atomically
   await regenerateSessionInDB(oldSessionId, newSessionId, memberId, expiry);
 
   // Set new cookie
-  res.cookie("session_id", newSessionId, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    maxAge: 180 * 86400 * 1000,
-  });
+  res.cookie(SESSION_COOKIE_NAME, newSessionId, sessionCookieOptions());
 }
 
 export async function destroyUserSession(req: MulmRequest, res: Response) {
-  res.cookie("session_id", null);
-  const token = String(req.cookies.session_id);
-  if (token !== undefined) {
+  const token = getSessionToken(req);
+  // Clear with matching attributes (path/secure) so the browser actually drops it.
+  res.clearCookie(SESSION_COOKIE_NAME, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+  });
+  if (token) {
     try {
       const conn = writeConn;
       const deleteRow = await conn.prepare("DELETE FROM sessions WHERE session_id = ?");

--- a/src/views/header.pug
+++ b/src/views/header.pug
@@ -4,9 +4,12 @@ include mixins/loadingSpinner.pug
 mixin headTag(title, ogData)
 	head
 		title= title
+		if csrfToken
+			meta(name="csrf-token" content=csrfToken)
 		link(rel='stylesheet', href='/index.css')
 		link(rel='stylesheet', href='/tom-select.css')
 		script(src='/htmx-2.0.4.js')
+		script(src='/js/csrf.js')
 		script(src='/tom-select.complete.min.js')
 		script(src=`/typeahead.js?v=${Date.now()}`)
 		script(src='/js/hoverCard.js')


### PR DESCRIPTION
Implements **all three phases of issue #19**. Phase 1 is the primary fix; Phases 2 and 3 add defense-in-depth (requested explicitly — the uncertain sibling-subdomain risk justifies the token layer).

## Phase 1 — Origin/Referer validation + hardening
- **Origin/Referer validation middleware** (`src/middleware/originValidation.ts`) on all POST/PUT/PATCH/DELETE: allowlist + self-origin (works behind Fly's proxy), rejects literal `null` Origin (RFC 6454), rejects missing-both-headers, Referer fallback, `ALLOWED_ORIGINS` override.
- **`__Host-` session cookie prefix** in production (Secure/Path=/, host-only); bare name in dev/test over HTTP; cookie name/options centralized in `sessions.ts`.
- **helmet non-CSP subset**: HSTS (prod), `X-Frame-Options: DENY`, `nosniff`.
- **`trust proxy: 1`** in production.
- **Guarded `GET /test-logout`** (+ `/test-login`) behind `devOnly`.

## Phase 2 — synchronizer CSRF tokens (defense-in-depth)
- Per-session `csrf_token` (**migration 055**, backfills existing sessions so nobody is logged out on deploy).
- Token surfaced to authenticated pages as `<meta name="csrf-token">` (via `res.locals` + the `headTag` mixin).
- `public/js/csrf.js` echoes it on every same-origin mutation: an `htmx:configRequest` listener (all hx-post/patch/delete) **and** a `fetch()` wrapper (image upload, passkey register, collection images). No per-call-site edits — the app has no plain POST forms.
- `csrfValidation` middleware enforces the token on **authenticated** state-changing requests; unauthenticated/tokenless-legacy requests fall through to Origin validation.

## Phase 3 — Content-Security-Policy (report-only first step)
- helmet **CSP in Report-Only mode** with a curated target policy, so the app's ~70 inline scripts/handlers can be observed and refactored before enforcement (enforcing now would break the UI — that refactor is the tracked follow-up).
- `/csp-report` collector endpoint (registered before the Origin/CSRF middleware so browser reports — which carry no Origin/token — aren't rejected) logs violations.
- Cookie signing intentionally skipped (`session_id` is already opaque random).

## Decisions (confirmed with owner)
- **Keep the existing 180-day cookie** (no idle/absolute-timeout change); session IDs already rotate on login.
- **Sibling-subdomain risk "yes/unsure"** → motivated shipping Phase 2 tokens now rather than deferring.

## Testing
- **26 new unit tests** (17 origin + 9 CSRF) covering same-origin pass, cross-origin/sibling/null/missing reject, Referer fallback, token match/mismatch/absent, legacy-session skip, method coverage.
- Full suite **1028 pass / 0 fail** (the only failures are the pre-existing `wikipedia`/`gbif` integration suites that need live network — unrelated).
- **End-to-end smoke test** against the running app: migration applies; CSP-RO header present; `/csp-report` → 204; authenticated mutation without/with/with-wrong token → 403/200/403; `<meta>` token rendered; cross-origin/null/missing POST → 403; helmet headers present.
- Note: the Playwright e2e suite wasn't run in this environment (no browser), but all e2e auth/mutation flows are HTMX/`fetch` and are covered by the global token handlers; logout is `hx-post`.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)