### PR TITLE
chore: add chikin browser automation MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
     "member-management": {
       "type": "http",
       "url": "http://127.0.0.1:3001/mcp/members"
+    },
+    "chikin-browser": {
+      "type": "http",
+      "url": "http://127.0.0.1:8080/b/mulm/"
     }
   }
 }


### PR DESCRIPTION
Adds a third MCP server entry (`chikin-browser`) to `.mcp.json` pointing at the local chikin Chrome-in-Docker gateway's per-browser endpoint.

## What
- New `chikin-browser` http entry → `http://127.0.0.1:8080/b/mulm/`
- The `mulm` name gives this project its own persistent, isolated browser via the gateway's documented per-browser endpoint (`/b/<name>/`).
- No auth token (gateway `GATEWAY_TOKEN` is unset; binds `127.0.0.1` only).

## Scope
- Pure config change; the two existing entries (`species-database`, `member-management`) are byte-for-byte unchanged.
- Does not start or depend on the chikin gateway running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)