### PR TITLE
fix(docker): run nodejs process under gid 1001 instead of nogroup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY litestream.yml /etc/litestream.yml
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nodejs -u 1001
+    adduser -S nodejs -u 1001 -G nodejs
 
 # Pre-create the data mount point owned by nodejs so Fly volumes (and local
 # docker volumes) inherit ownership on first init.


### PR DESCRIPTION
## What
The alpine runner stage created the runtime user with `adduser -S nodejs -u 1001`, which sets the uid but omits a group. Alpine's `adduser -S` then places the user in the default `nogroup` (gid 65533) rather than the `nodejs` group (gid 1001) that the preceding `addgroup -g 1001 -S nodejs` already defines.

## Fix
Add `-G nodejs` to the `adduser` line so the primary group is `nodejs` (gid 1001). The group already exists one line above, so no new group line is needed — minimal change scoped strictly to the user/group setup (base image and everything else untouched).

## Verification
Replicated the runner-stage user/group commands in `node:22-alpine`:

```
$ adduser -S nodejs -u 1001 -G nodejs; su nodejs -c id
uid=1001(nodejs) gid=1001(nodejs) groups=1001(nodejs)
```

A full `docker build` was not run (heavy npm ci / network); the isolated check above confirms the resulting gid, and the group is defined before use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)